### PR TITLE
fix(git.release): fallback to direct merge when automerge unavailable

### DIFF
--- a/.radio
+++ b/.radio
@@ -1,0 +1,1 @@
+/home/vlad/git/.radio/ehmpathy/rhachet-roles-ehmpathy

--- a/src/domain.roles/mechanic/skills/claude.tools/grepsafe.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/claude.tools/grepsafe.integration.test.ts
@@ -50,7 +50,7 @@ describe('grepsafe.sh', () => {
    */
   const sanitizeOutput = (stdout: string): string => {
     // replace temp paths
-    let output = stdout.replace(/\/tmp\/[^\s]+/g, '/tmp/TEMP_DIR');
+    const output = stdout.replace(/\/tmp\/[^\s]+/g, '/tmp/TEMP_DIR');
 
     // sort grep result lines for deterministic order
     // matches lines like "src/a.ts:1:content" or "│  src/a.ts:1:content"

--- a/src/domain.roles/mechanic/skills/git.release/.test/infra/mockGh.ts
+++ b/src/domain.roles/mechanic/skills/git.release/.test/infra/mockGh.ts
@@ -1247,6 +1247,23 @@ if [[ "$CMD_KEY" == "pr view" ]] && [[ "$ALL_ARGS" == *"--json mergeCommit"* ]];
   exit 0
 fi
 
+# distinguish "pr merge" subvariants: --auto vs direct merge
+if [[ "$CMD_KEY" == "pr merge" ]]; then
+  if [[ "$ALL_ARGS" == *"--auto"* ]]; then
+    # check for "pr merge auto" key first, fallback to "pr merge"
+    RESPONSE_AUTO=$(echo "$MOCK_RESPONSES" | jq -r '.["pr merge auto"] // empty')
+    if [[ -n "$RESPONSE_AUTO" ]]; then
+      CMD_KEY="pr merge auto"
+    fi
+  else
+    # direct merge (no --auto): check for "pr merge direct" key first
+    RESPONSE_DIRECT=$(echo "$MOCK_RESPONSES" | jq -r '.["pr merge direct"] // empty')
+    if [[ -n "$RESPONSE_DIRECT" ]]; then
+      CMD_KEY="pr merge direct"
+    fi
+  fi
+fi
+
 # distinguish "pr list" subvariants by --state flag and --jq query
 if [[ "$CMD_KEY" == "pr list" ]]; then
   # check for --limit 21 query FIRST (get_latest_merged_release_pr_info)

--- a/src/domain.roles/mechanic/skills/git.release/__snapshots__/git.release.p1.integration.test.ts.snap
+++ b/src/domain.roles/mechanic/skills/git.release/__snapshots__/git.release.p1.integration.test.ts.snap
@@ -117,6 +117,22 @@ exports[`git.release given: [case2] release to main (apply mode) when: [t4] auto
 "
 `;
 
+exports[`git.release given: [case2] release to main (apply mode) when: [t5] automerge unavailable but direct merge succeeds (free tier) then: falls back to direct merge, exits 0 1`] = `
+"🐢 cowabunga!
+
+🐚 git.release --into main --mode apply --watch
+
+🌊 release: feat(oceans): add reef protection
+   ├─ 👌 all checks passed
+   ├─ 🌴 automerge enabled [added]
+   └─ 🥥 let's watch
+      ├─ 🫧 no runs inflight
+      └─ ✨ done! Xs in action, Xs watched
+
+[dim]🐚 continue?: rhx git.release --into prod --mode apply[/dim]
+"
+`;
+
 exports[`git.release given: [case3a] release to prod from main (plan mode) when: [t0] release PR extant then: shows status with hint to apply 1`] = `
 "🐢 heres the wave...
 

--- a/src/domain.roles/mechanic/skills/git.release/git.release.operations.sh
+++ b/src/domain.roles/mechanic/skills/git.release/git.release.operations.sh
@@ -390,11 +390,15 @@ get_pr_title() {
 ######################################################################
 # enable_automerge
 # enable automerge on PR via gh pr merge --auto --squash
+# falls back to direct merge if automerge is unavailable (free tier orgs)
 #
 # handles "clean status" error: when PR is ready to merge now, gh returns
 # "GraphQL: Pull request is in clean status (enablePullRequestAutoMerge)"
 # this is NOT an error - it means the PR merged or can merge immediately.
 # we suppress this specific error and let the caller check merge status.
+#
+# handles "automerge unavailable" error: when org/repo doesn't support
+# automerge (free tier), falls back to direct merge via gh pr merge --squash
 #
 # usage: enable_automerge "42"
 # returns: 0 on success or "clean status", non-zero on actual errors
@@ -417,6 +421,31 @@ enable_automerge() {
   if echo "$output" | grep -qi "clean status"; then
     # suppress error, let caller check if PR merged
     return 0
+  fi
+
+  # check for automerge unavailable errors (free tier orgs, repo settings)
+  # note: "not authorized" is a permissions error, NOT automerge unavailability
+  # patterns: "Auto merge is not allowed for this repository", "not enabled"
+  if echo "$output" | grep -qiE "(auto[- ]?merge is not allowed|not enabled|auto_merge_allowed)"; then
+    # fallback to direct merge (without --auto)
+    local direct_output
+    local direct_exit_code
+    direct_output=$(gh pr merge "$pr_number" --squash 2>&1) && direct_exit_code=0 || direct_exit_code=$?
+
+    if [[ $direct_exit_code -eq 0 ]]; then
+      # direct merge succeeded
+      return 0
+    fi
+
+    # check for "clean status" on direct merge too
+    if echo "$direct_output" | grep -qi "clean status"; then
+      return 0
+    fi
+
+    # direct merge also failed - failloud with original automerge error + fallback error
+    echo "automerge unavailable (free tier?): $output" >&2
+    echo "direct merge also failed: $direct_output" >&2
+    return $direct_exit_code
   fi
 
   # actual error - failloud

--- a/src/domain.roles/mechanic/skills/git.release/git.release.p1.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.release/git.release.p1.integration.test.ts
@@ -491,6 +491,50 @@ exit 1
         }
       });
     });
+
+    when('[t5] automerge unavailable but direct merge succeeds (free tier)', () => {
+      then('falls back to direct merge, exits 0', () => {
+        // automerge fails with "not allowed" (free tier), but direct merge succeeds
+        const mockResponses = {
+          'pr list': '42',
+          'pr view':
+            '{"statusCheckRollup": [{"conclusion": "SUCCESS", "status": "COMPLETED", "name": "test"}], "autoMergeRequest": null, "mergeStateStatus": "CLEAN", "state": "OPEN", "title": "feat(oceans): add reef protection"}',
+          'pr merge auto':
+            'ERROR:GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)',
+          'pr merge direct': 'Squash and merge pull request #42',
+        };
+
+        const { tempDir, fakeBinDir, cleanup } = setupTestEnv(mockResponses);
+
+        try {
+          spawnSync('git', ['checkout', '-b', 'turtle/feature-x'], {
+            cwd: tempDir,
+          });
+
+          const result = runSkill(['--into', 'main', '--mode', 'apply'], {
+            tempDir,
+            fakeBinDir,
+          });
+
+          // debug output
+          console.log('case2 t5 STDOUT:', result.stdout);
+          console.log('case2 t5 STDERR:', result.stderr);
+          console.log('case2 t5 STATUS:', result.status);
+
+          // fallback succeeds: skill exits 0
+          expect(result.status).toEqual(0);
+
+          // stdout shows success
+          expect(result.stdout).toContain('cowabunga');
+          expect(result.stdout).toContain('all checks passed');
+
+          // snapshots capture exact output
+          expect(asSnapshotReadyWithAnsi(result.stdout)).toMatchSnapshot();
+        } finally {
+          cleanup();
+        }
+      });
+    });
   });
 
   given('[case3a] release to prod from main (plan mode)', () => {

--- a/src/domain.roles/mechanic/skills/git.release/git.release.p1.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.release/git.release.p1.integration.test.ts
@@ -492,49 +492,52 @@ exit 1
       });
     });
 
-    when('[t5] automerge unavailable but direct merge succeeds (free tier)', () => {
-      then('falls back to direct merge, exits 0', () => {
-        // automerge fails with "not allowed" (free tier), but direct merge succeeds
-        const mockResponses = {
-          'pr list': '42',
-          'pr view':
-            '{"statusCheckRollup": [{"conclusion": "SUCCESS", "status": "COMPLETED", "name": "test"}], "autoMergeRequest": null, "mergeStateStatus": "CLEAN", "state": "OPEN", "title": "feat(oceans): add reef protection"}',
-          'pr merge auto':
-            'ERROR:GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)',
-          'pr merge direct': 'Squash and merge pull request #42',
-        };
+    when(
+      '[t5] automerge unavailable but direct merge succeeds (free tier)',
+      () => {
+        then('falls back to direct merge, exits 0', () => {
+          // automerge fails with "not allowed" (free tier), but direct merge succeeds
+          const mockResponses = {
+            'pr list': '42',
+            'pr view':
+              '{"statusCheckRollup": [{"conclusion": "SUCCESS", "status": "COMPLETED", "name": "test"}], "autoMergeRequest": null, "mergeStateStatus": "CLEAN", "state": "OPEN", "title": "feat(oceans): add reef protection"}',
+            'pr merge auto':
+              'ERROR:GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)',
+            'pr merge direct': 'Squash and merge pull request #42',
+          };
 
-        const { tempDir, fakeBinDir, cleanup } = setupTestEnv(mockResponses);
+          const { tempDir, fakeBinDir, cleanup } = setupTestEnv(mockResponses);
 
-        try {
-          spawnSync('git', ['checkout', '-b', 'turtle/feature-x'], {
-            cwd: tempDir,
-          });
+          try {
+            spawnSync('git', ['checkout', '-b', 'turtle/feature-x'], {
+              cwd: tempDir,
+            });
 
-          const result = runSkill(['--into', 'main', '--mode', 'apply'], {
-            tempDir,
-            fakeBinDir,
-          });
+            const result = runSkill(['--into', 'main', '--mode', 'apply'], {
+              tempDir,
+              fakeBinDir,
+            });
 
-          // debug output
-          console.log('case2 t5 STDOUT:', result.stdout);
-          console.log('case2 t5 STDERR:', result.stderr);
-          console.log('case2 t5 STATUS:', result.status);
+            // debug output
+            console.log('case2 t5 STDOUT:', result.stdout);
+            console.log('case2 t5 STDERR:', result.stderr);
+            console.log('case2 t5 STATUS:', result.status);
 
-          // fallback succeeds: skill exits 0
-          expect(result.status).toEqual(0);
+            // fallback succeeds: skill exits 0
+            expect(result.status).toEqual(0);
 
-          // stdout shows success
-          expect(result.stdout).toContain('cowabunga');
-          expect(result.stdout).toContain('all checks passed');
+            // stdout shows success
+            expect(result.stdout).toContain('cowabunga');
+            expect(result.stdout).toContain('all checks passed');
 
-          // snapshots capture exact output
-          expect(asSnapshotReadyWithAnsi(result.stdout)).toMatchSnapshot();
-        } finally {
-          cleanup();
-        }
-      });
-    });
+            // snapshots capture exact output
+            expect(asSnapshotReadyWithAnsi(result.stdout)).toMatchSnapshot();
+          } finally {
+            cleanup();
+          }
+        });
+      },
+    );
   });
 
   given('[case3a] release to prod from main (plan mode)', () => {


### PR DESCRIPTION
fix(git.release): fallback to direct merge when automerge unavailable

- detect "Auto merge is not allowed" error (free tier orgs)
- fallback to gh pr merge --squash (without --auto)
- note: "not authorized" is a permissions error, not automerge unavailability
- add mock support for distinguishing pr merge auto vs direct

---
🐢🌊 surfed in by seaturtle[bot]