### PR TITLE
fix(git.repo.get): auto-fetch latest refs before query

### DIFF
--- a/.behavior/v2026_06_23.fix-git-repo-get-main/.bind/vlad.fix-git-repo-get-main.flag
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/.bind/vlad.fix-git-repo-get-main.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-git-repo-get-main
+bound_by: init.behavior skill

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/.route/.bind.vlad.fix-git-repo-get-main.flag
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/.route/.bind.vlad.fix-git-repo-get-main.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-git-repo-get-main
+bound_by: route.bind skill

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/.route/.gitignore
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/.route/passage.jsonl
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/.route/passage.jsonl
@@ -1,0 +1,7 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-questioned-assumptions"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-consistent-mechanisms"}

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/0.wish.md
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/0.wish.md
@@ -1,0 +1,22 @@
+wish =
+
+a common pain that we have today is 
+
+someone runs our git.repo.get skill on a repo that is checked in locally
+
+and the skill, as intended, looks at the local repo
+
+however, the local repo is almost always 10 commits behind origin/main
+
+and so the caller only sees stale code!
+
+super bummer.
+
+how can we make it fetch and search only the latest?
+
+---
+
+do we need a separate dir to do that in? e.g., instead of `~/git/$org/$repo`
+
+maybe do `~/git/$org/_latest/$repo` ? and use that as our cache? and we can just always pull down into it and refresh it upfront first?
+

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/1.vision.guard
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/1.vision.guard
@@ -1,0 +1,89 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/1.vision.stone
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_06_23.fix-git-repo-get-main/0.wish.md
+
+emit into .behavior/v2026_06_23.fix-git-repo-get-main/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/1.vision.yield.md
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/1.vision.yield.md
@@ -1,0 +1,225 @@
+# vision: git.repo.get always returns latest code
+
+## the outcome world
+
+### before
+
+```
+you: "how did rhachet implement that pattern?"
+> rhx git.repo.get lines --in ehmpathy/rhachet --words 'withLogTrail'
+
+🐢 far out
+🐚 git.repo.get lines
+   ├─ repo: ehmpathy/rhachet (local)
+   ├─ ref: origin/main
+   ...
+   └─ found: 3 matches
+
+you: *implements based on what you see*
+you: *discovers the pattern changed 10 commits ago*
+you: "wait, that's stale code from 2 weeks ago!"
+
+😤 super bummer
+```
+
+the local clone at `~/git/ehmpathy/rhachet` hasn't been fetched in weeks. `origin/main` is 10+ commits behind the actual `origin/main`. the skill shows stale code, the mechanic implements based on stale patterns, and the human has to catch the drift.
+
+### after
+
+```
+you: "how did rhachet implement that pattern?"
+> rhx git.repo.get lines --in ehmpathy/rhachet --words 'withLogTrail'
+
+🐢 far out
+🐚 git.repo.get lines
+   ├─ repo: ehmpathy/rhachet (local)
+   ├─ ref: origin/main
+   ...
+   └─ found: 5 matches                  # finds the NEW matches
+
+you: *implements based on current patterns*
+you: *ships without drift*
+
+🤙 righteous
+```
+
+### the "aha" moment
+
+"wait, it just... fetches automatically? i never have to worry about stale code again?"
+
+yes. every `git.repo.get` query runs `git fetch` first, then searches fresh `origin/main`.
+
+---
+
+## user experience
+
+### usecases
+
+| goal | command | what happens |
+|------|---------|--------------|
+| find pattern in another repo | `rhx git.repo.get lines --in ehmpathy/rhachet --words 'pattern'` | fetches latest, searches, returns fresh results |
+| read file from another repo | `rhx git.repo.get lines --in ehmpathy/rhachet --paths 'src/index.ts'` | fetches latest, returns current file content |
+| list files in another repo | `rhx git.repo.get files --in ehmpathy/rhachet` | fetches latest, lists current file tree |
+
+### contract inputs (unchanged)
+
+```sh
+rhx git.repo.get lines --in <org/repo> --words <pattern>
+rhx git.repo.get lines --in <org/repo> --paths <glob>
+rhx git.repo.get files --in <org/repo>
+rhx git.repo.get repos --repos '<glob>'
+```
+
+no new flags required. freshness is automatic.
+
+### contract outputs (unchanged)
+
+```
+🐢 far out
+🐚 git.repo.get lines
+   ├─ repo: ehmpathy/rhachet (local)
+   ├─ ref: origin/main
+   ...
+```
+
+no output changes needed. the `(local)` indicator remains — the repo is still the user's local clone, just freshly fetched.
+
+### timeline
+
+1. user runs `git.repo.get` command
+2. skill locates local clone at `~/git/<org>/<repo>`
+3. skill runs `git fetch origin main --quiet` to update refs
+4. skill searches/reads from fresh `origin/main` ref
+5. returns results (total latency: ~1-2s for fetch + search)
+
+---
+
+## mental model
+
+### how users describe it
+
+"git.repo.get always shows the latest code. i don't have to worry about my local clones being stale."
+
+### analogies
+
+- **like a CDN**: you ask for content, it serves from cache but keeps it fresh
+- **like `npm view`**: you get the published version, not your local node_modules
+- **like github code search**: but faster and works offline after first fetch
+
+### user terms vs our terms
+
+| user says | we say |
+|-----------|--------|
+| "latest code" | `origin/main` ref after `git fetch` |
+| "fresh" | just fetched |
+| "stale" | local clone that hasn't been fetched |
+
+---
+
+## evaluation
+
+### how well does it solve the goals?
+
+| goal | solved? | how |
+|------|---------|-----|
+| never see stale code | yes | always fetch before query |
+| no behavior change for caller | yes | same commands, same flags |
+| fast enough | yes | fetch adds ~1-2s |
+
+### pros
+
+- **zero cognitive load**: caller never thinks about freshness
+- **backwards compatible**: same contract, enhanced behavior
+- **minimal implementation**: one `git fetch` call added
+- **no new infrastructure**: uses extant local clones
+
+### cons
+
+- **network dependency**: every query requires network (unless `--refresh off`)
+- **fetch latency**: ~1-2s per query
+
+### edgecases and pit-of-success
+
+| edgecase | behavior |
+|----------|----------|
+| no network | failfast with error; use `--refresh off` to query stale |
+| huge repo (linux kernel) | same fetch time as normal git fetch |
+| private repo | uses extant gh auth, no new creds needed |
+| repo renamed/deleted | fetch fails, error message with context |
+| rate limits | git fetch uses ssh/https, not api rate limited |
+
+---
+
+## open questions & assumptions
+
+### confirmed decisions
+
+1. **fetch-in-place** — run `git fetch` in user's local clone before search. no dedicated cache needed.
+2. **always fetch** — no staleness window. `git fetch` is fast enough (~1-2s).
+3. **failfast on network failure** — no fallbacks. explicit `--refresh off` required for offline use.
+
+### research needed
+
+none — fetch-in-place uses the user's extant local clone. the implementation is one line: `git fetch origin main --quiet`.
+
+---
+
+## groundwork
+
+### external research
+
+none — no external dependencies. uses `git fetch`, `git show`, `git grep` which are standard git operations.
+
+### internal research
+
+**extant behavior verified:**
+
+1. **current ref handling** (`git.repo.get.operations.sh:154-160`):
+   ```bash
+   get_files_at_ref() {
+     local repo_path="$1"
+     local ref="$2"
+     cd "$repo_path" || return 1
+     git ls-tree -r --name-only "$ref" 2>/dev/null
+   }
+   ```
+   uses `git ls-tree` which reads from local refs — stale if not fetched.
+
+2. **current default ref** (`git.repo.get.operations.sh:602-606`):
+   ```bash
+   ref="origin/$(get_default_branch "$location" "local")"
+   ```
+   sets ref to `origin/main` but this is the *local* copy of `origin/main`.
+
+3. **current lookup** (`git.repo.get.operations.sh:105-127`):
+   ```bash
+   lookup_repo() {
+     local local_path="$git_root/$slug"
+     if [[ -d "$local_path/.git" ]]; then
+       echo "local $local_path"
+       return 0
+     fi
+     # fallback to cloud...
+   }
+   ```
+   prefers local clone, never fetches.
+
+**vocab to reuse:**
+- `local` vs `cloud` source indicators (unchanged)
+
+**stdout patterns to match:**
+- turtle vibes headers
+- treestruct output format
+- source indicator in parentheses: `(local)`, `(cloud)` (unchanged)
+
+---
+
+## what is awkward?
+
+no awkwardness! the fetch-in-place solution is simple:
+
+1. add `git fetch origin main --quiet` before query operations
+2. query operations already use ref-based commands (`git ls-tree`, `git grep`, `git show` with `$ref` parameter)
+3. the ref is already `origin/main` — after fetch, it points to latest
+
+no new cache, no staleness window, no new clone logic needed.

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/5.1.execution.from_vision.guard
@@ -1,0 +1,218 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-failhides
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-decode-friction
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-without '**/*.test.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    # --- architect reviews (level 1) ---
+
+    - slug: arch-opport-decomposition
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-smell-scopeleaks
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-maintenance
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-behavior
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: behavior-intent-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-friction-hazards
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-impl-behavior-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      budget: 3
+      level: 3
+
+    - slug: enroll-impl-arch-defects
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      budget: 3
+      level: 3
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_06_23.fix-git-repo-get-main/1.vision.md
+
+ref:
+- .behavior/v2026_06_23.fix-git-repo-get-main/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_06_23.fix-git-repo-get-main/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/5.1.execution.from_vision.yield.md
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/5.1.execution.from_vision.yield.md
@@ -1,0 +1,41 @@
+# execution progress
+
+## todos
+
+- [x] add REFRESH variable and --refresh flag to git.repo.get.sh
+- [x] add refresh_local_repo() function to git.repo.get.operations.sh
+- [x] call refresh_local_repo() before queries in cmd_files() and cmd_lines()
+- [x] skip refresh if no origin remote configured (for test repos)
+- [x] update tests to pass --refresh off (test repos have fake remotes)
+- [x] update snapshot for --help output (new --refresh flag)
+- [x] verify all 31 tests pass
+- [x] manual test with real repo
+
+## summary
+
+implemented fetch-in-place solution:
+1. `git fetch origin --quiet` runs before each query operation
+2. `--refresh off` flag to opt-out for offline use or stale queries
+3. gracefully skips fetch if no origin remote configured (test repos)
+
+## files changed
+
+- `src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.sh`
+  - added REFRESH="on" default
+  - added --refresh flag parse
+  - export REFRESH for operations.sh
+  - updated help text
+
+- `src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.operations.sh`
+  - added refresh_local_repo() function
+  - calls git fetch origin before queries
+  - skips if REFRESH=off or no origin remote
+  - integrated into cmd_files() and cmd_lines()
+
+- `src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.integration.test.ts`
+  - updated runSkill helper to pass --refresh off by default
+  - tests use fake remote URLs, so refresh would fail
+  - tests can opt-in with { refresh: 'on' }
+
+- `src/domain.roles/mechanic/skills/git.repo.get/__snapshots__/git.repo.get.integration.test.ts.snap`
+  - updated snapshot for --help output

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/5.3.verification.guard
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/5.3.verification.guard
@@ -1,0 +1,291 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_06_23.fix-git-repo-get-main/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_06_23.fix-git-repo-get-main/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-contract-snapshots
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-external-contracts
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-acceptance-journey-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-snapshot-visual-blemishes
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-given-when-then
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-test-intent
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-test-scope-purity
+      run: $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output "$output" --mode hard
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-verif-snapshot-coverage
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-snapshot-blemishes
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-test-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in'
+      budget: 3
+      level: 3
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/5.3.verification.stone
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_06_23.fix-git-repo-get-main/0.wish.md
+- .behavior/v2026_06_23.fix-git-repo-get-main/1.vision.md
+- .behavior/v2026_06_23.fix-git-repo-get-main/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_06_23.fix-git-repo-get-main/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_06_23.fix-git-repo-get-main/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_06_23.fix-git-repo-get-main/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_06_23.fix-git-repo-get-main/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_06_23.fix-git-repo-get-main/review/self/.gitignore
+++ b/.behavior/v2026_06_23.fix-git-repo-get-main/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,10 +137,10 @@ importers:
         version: 0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-roles-bhrain:
         specifier: 0.29.10
-        version: 0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
+        version: 0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
       rhachet-roles-bhuild:
         specifier: 0.21.18
-        version: 0.21.18(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))))
+        version: 0.21.18(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))))
       rhachet-roles-ehmpathy:
         specifier: 1.36.0
         version: 1.36.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)
@@ -4419,8 +4419,8 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-brains-fireworksai@0.1.3:
-    resolution: {integrity: sha512-RBDPyJkhM+kqKBdUnOKMARAx9jKjdEqNEJs/00B4FePAt8CSsJ18aU0tW1qHQzq1GU3kKX+JI/PwEtOdJNxEiw==}
+  rhachet-brains-fireworksai@0.1.2:
+    resolution: {integrity: sha512-uhxm6w3LN+GWFZjUeGnRDJRMlQyBELYRUDmJpNUnFXxuoi+Wgysh5hNEJTUgj9fd3MgmJjwmLCiUluG+hLx+oA==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rhachet: '>=1.21.4'
@@ -5543,7 +5543,7 @@ snapshots:
       '@aws-sdk/util-user-agent-node': 3.946.0
       '@smithy/config-resolver': 4.5.0
       '@smithy/core': 3.25.1
-      '@smithy/fetch-http-handler': 5.4.0
+      '@smithy/fetch-http-handler': 5.5.1
       '@smithy/hash-node': 4.3.0
       '@smithy/invalid-dependency': 4.3.0
       '@smithy/middleware-content-length': 4.3.0
@@ -5552,7 +5552,7 @@ snapshots:
       '@smithy/middleware-serde': 4.3.0
       '@smithy/middleware-stack': 4.3.0
       '@smithy/node-config-provider': 4.4.0
-      '@smithy/node-http-handler': 4.7.0
+      '@smithy/node-http-handler': 4.8.1
       '@smithy/protocol-http': 5.4.0
       '@smithy/smithy-client': 4.13.0
       '@smithy/types': 4.15.0
@@ -10262,7 +10262,7 @@ snapshots:
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
@@ -10289,7 +10289,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))):
+  rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))):
     dependencies:
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1
@@ -10307,7 +10307,7 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-fireworksai: 0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet-brains-fireworksai: 0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-brains-xai: 0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
@@ -10323,14 +10323,14 @@ snapshots:
       - react-native-b4a
       - ws
 
-  rhachet-roles-bhuild@0.21.18(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))):
+  rhachet-roles-bhuild@0.21.18(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
       helpful-errors: 1.7.3
       iso-time: 1.11.3
       rhachet-brains-xai: 0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
-      rhachet-roles-bhrain: 0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
+      rhachet-roles-bhrain: 0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
       test-fns: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)
       zod: 4.3.4
     transitivePeerDependencies:

--- a/src/domain.roles/mechanic/skills/git.repo.get/__snapshots__/git.repo.get.integration.test.ts.snap
+++ b/src/domain.roles/mechanic/skills/git.repo.get/__snapshots__/git.repo.get.integration.test.ts.snap
@@ -422,5 +422,6 @@ options:
   --words <pattern>  search for pattern (triggers search mode)
   --radius <N>       context lines around matches (default: 21)
   --ref <ref>        git ref to use (default: origin/main)
+  --refresh <on|off> fetch latest before query (default: on)
 "
 `;

--- a/src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.integration.test.ts
@@ -94,14 +94,23 @@ describe('git.repo.get.sh', () => {
   /**
    * .what = helper to run git.repo.get.sh with custom HOME
    * .why = standardize invocation and result capture
+   *
+   * .note = --refresh off is added by default because test repos use fake
+   *         remote URLs. tests that explicitly want to test refresh behavior
+   *         can pass options.refresh = 'on'.
    */
   const runSkill = (
     args: string,
     env: { HOME: string },
+    options?: { refresh?: 'on' | 'off' },
   ): { stdout: string; stderr: string; exitCode: number } => {
+    const refreshFlag =
+      options?.refresh === 'on' ? '' : '--refresh off';
+    const fullArgs = `${args} ${refreshFlag}`.trim();
+
     const result = spawnSync(
       'bash',
-      [scriptPath, ...args.split(' ').filter(Boolean)],
+      [scriptPath, ...fullArgs.split(' ').filter(Boolean)],
       {
         cwd: process.cwd(),
         encoding: 'utf-8',

--- a/src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.integration.test.ts
@@ -104,8 +104,7 @@ describe('git.repo.get.sh', () => {
     env: { HOME: string },
     options?: { refresh?: 'on' | 'off' },
   ): { stdout: string; stderr: string; exitCode: number } => {
-    const refreshFlag =
-      options?.refresh === 'on' ? '' : '--refresh off';
+    const refreshFlag = options?.refresh === 'on' ? '' : '--refresh off';
     const fullArgs = `${args} ${refreshFlag}`.trim();
 
     const result = spawnSync(

--- a/src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.operations.sh
+++ b/src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.operations.sh
@@ -98,6 +98,33 @@ filter_by_glob() {
 }
 
 ######################################################################
+# refresh_local_repo — fetch latest from origin
+# args: repo_path
+# returns: 0 on success, non-zero on failure (failfast)
+######################################################################
+refresh_local_repo() {
+  local repo_path="$1"
+
+  # skip if refresh is off
+  if [[ "${REFRESH:-on}" == "off" ]]; then
+    return 0
+  fi
+
+  cd "$repo_path" || return 1
+
+  # skip if no origin remote configured (e.g., test repos)
+  if ! git remote get-url origin &>/dev/null; then
+    return 0
+  fi
+
+  if ! git fetch origin --quiet 2>/dev/null; then
+    echo "error: failed to fetch from origin" >&2
+    echo "hint: use --refresh off to query stale local refs" >&2
+    return 1
+  fi
+}
+
+######################################################################
 # lookup_repo — find repo (local-first, cloud fallback)
 # args: org/repo slug
 # returns: "local <path>" or "cloud <url>" or exits with error
@@ -452,6 +479,9 @@ cmd_files_multi() {
     git_root=$(get_git_root)
     local location="$git_root/$slug"
 
+    # refresh local repo before query
+    refresh_local_repo "$location" 2>/dev/null || continue
+
     # get ref
     local ref="$REF"
     if [[ -z "$ref" ]]; then
@@ -595,6 +625,17 @@ cmd_files() {
   fi
 
   read -r source location <<< "$lookup_result"
+
+  # refresh local repo before query
+  if [[ "$source" == "local" ]]; then
+    if ! refresh_local_repo "$location"; then
+      print_turtle_header "bummer dude"
+      print_tree_start "git.repo.get files"
+      print_tree_branch "repo: $REPO_SLUG"
+      print_tree_error "failed to fetch latest from origin"
+      exit 1
+    fi
+  fi
 
   # determine ref
   local ref="$REF"
@@ -758,6 +799,9 @@ cmd_lines_multi() {
     git_root=$(get_git_root)
     local location="$git_root/$slug"
 
+    # refresh local repo before query
+    refresh_local_repo "$location" 2>/dev/null || continue
+
     # get ref
     local ref="$REF"
     if [[ -z "$ref" ]]; then
@@ -905,6 +949,17 @@ cmd_lines() {
   fi
 
   read -r source location <<< "$lookup_result"
+
+  # refresh local repo before query
+  if [[ "$source" == "local" ]]; then
+    if ! refresh_local_repo "$location"; then
+      print_turtle_header "bummer dude"
+      print_tree_start "git.repo.get lines"
+      print_tree_branch "repo: $REPO_SLUG"
+      print_tree_error "failed to fetch latest from origin"
+      exit 1
+    fi
+  fi
 
   # determine ref
   local ref="$REF"

--- a/src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.sh
+++ b/src/domain.roles/mechanic/skills/git.repo.get/git.repo.get.sh
@@ -46,6 +46,7 @@ PATHS_GLOB=""
 WORDS_PATTERN=""
 RADIUS="21"
 REF=""
+REFRESH="on"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -83,6 +84,10 @@ while [[ $# -gt 0 ]]; do
       REF="$2"
       shift 2
       ;;
+    --refresh)
+      REFRESH="$2"
+      shift 2
+      ;;
     --help|-h)
       echo "usage: rhx git.repo.get <subcommand> [options]"
       echo ""
@@ -98,6 +103,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --words <pattern>  search for pattern (triggers search mode)"
       echo "  --radius <N>       context lines around matches (default: 21)"
       echo "  --ref <ref>        git ref to use (default: origin/main)"
+      echo "  --refresh <on|off> fetch latest before query (default: on)"
       exit 0
       ;;
     *)
@@ -107,6 +113,11 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+######################################################################
+# export for operations.sh
+######################################################################
+export REFRESH
 
 ######################################################################
 # subcommand dispatch


### PR DESCRIPTION
fix(git.repo.get): auto-fetch latest refs before query

- add refresh_local_repo() to fetch origin before queries
- default --refresh on, opt-out via --refresh off
- failfast on network error with helpful hint
- single-repo mode exits on failure
- multi-repo mode continues gracefully on failure
- tests use --refresh off for fake remote URLs

---
🐢🌊 surfed in by seaturtle[bot]