### PR TITLE
feat(git.commit.uses): add org-level granularity for commit permissions

### DIFF
--- a/.behavior/v2026_06_22.git-commit-uses-grain/.bind/vlad.git-commit-uses-grain.flag
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.bind/vlad.git-commit-uses-grain.flag
@@ -1,0 +1,2 @@
+branch: vlad/git-commit-uses-grain
+bound_by: init.behavior skill

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.review/self/for.3.3.1.blueprint.product._.r1.has-research-citations.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.review/self/for.3.3.1.blueprint.product._.r1.has-research-citations.md
@@ -1,0 +1,40 @@
+# self-review: has-research-citations
+
+## found
+
+**ISSUE**: blueprint did not cite research results on initial write.
+
+## fix applied
+
+added "## research citations" section to blueprint with:
+
+1. production research citations (7 patterns):
+   - dispatcher pattern [REUSE]
+   - global handler structure [REUSE]
+   - global storage path [REUSE]
+   - global blocker check [EXTEND]
+   - radio.uses.org (bhuild) [REUSE]
+   - keyrack.yml org detection [REUSE]
+   - turtle vibes output [REUSE]
+
+2. test research citations (5 patterns):
+   - temp git repo [REUSE]
+   - isolated HOME [EXTEND]
+   - TTY guard bypass [REUSE]
+   - BDD structure [REUSE]
+   - radio.uses.org tests [REUSE]
+
+3. new behavior documentation:
+   - @all reset (not in radio.uses)
+   - keyrack.yml failfast
+
+## verification
+
+each research pattern is now cited with:
+- yield file reference
+- original source line numbers
+- usage in blueprint
+
+## lesson
+
+always add research citations section when draft blueprint. research done but not cited is effort not visible.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r1._.given.by_peer.repo-rules.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r1._.given.by_peer.repo-rules.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r2._.given.by_peer.mech-failhides.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r2._.given.by_peer.mech-failhides.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r3._.given.by_peer.mech-decode-friction.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r3._.given.by_peer.mech-decode-friction.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r4._.given.by_peer.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r4._.given.by_peer.arch-opport-decomposition.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r5._.given.by_peer.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r5._.given.by_peer.arch-smell-scopeleaks.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r6._.given.by_peer.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r6._.given.by_peer.arch-hazards-maintenance.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r7._.given.by_peer.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r7._.given.by_peer.arch-hazards-behavior.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r8._.given.by_peer.arch-ambiguous-terms.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r8._.given.by_peer.arch-ambiguous-terms.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i1.7b17d6a2dc0fc07e88.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
@@ -1,0 +1,70 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108
+│  │              throw new BrainChoiceNotFoundError_1.BrainChoiceNotFoundError(`brain not found: ${input.choice}
+│  │                    ^
+│  │  
+│  │  BrainChoiceNotFoundError: BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+│  │  
+│  │  🔭 available brains
+│  │     ├── ○ xai/grok/code-fast-1
+│  │     ├── ○ xai/grok/4-fast-wout-reason
+│  │     ├── ○ xai/grok/4-fast-with-reason
+│  │     ├── ○ anthropic/claude/opus
+│  │     ├── ○ anthropic/claude/haiku
+│  │     ├── ○ anthropic/claude/sonnet
+│  │     ├── ○ xai/grok/3-mini
+│  │     ├── ○ xai/grok/4
+│  │     ├── ○ xai/grok/4.1-fast-wout-reason
+│  │     ├── ○ xai/grok/4.1-fast-with-reason
+│  │     ├── ↻ anthropic/claude/code
+│  │     ├── ↻ anthropic/claude/code/opus
+│  │     ├── ○ xai/grok/3
+│  │     ├── ↻ anthropic/claude/code/haiku
+│  │     └── ↻ anthropic/claude/code/sonnet
+│  │  
+│  │  {
+│  │    "choice": "fireworks/deepseek/v4-flash",
+│  │    "available": {
+│  │      "atoms": [
+│  │        "anthropic/claude/haiku",
+│  │        "anthropic/claude/sonnet",
+│  │        "anthropic/claude/opus",
+│  │        "xai/grok/code-fast-1",
+│  │        "xai/grok/3",
+│  │        "xai/grok/3-mini",
+│  │        "xai/grok/4",
+│  │        "xai/grok/4-fast-wout-reason",
+│  │        "xai/grok/4-fast-with-reason",
+│  │        "xai/grok/4.1-fast-wout-reason",
+│  │        "xai/grok/4.1-fast-with-reason"
+│  │      ],
+│  │      "repls": [
+│  │        "anthropic/claude/code",
+│  │        "anthropic/claude/code/haiku",
+│  │        "anthropic/claude/code/sonnet",
+│  │        "anthropic/claude/code/opus"
+│  │      ]
+│  │    }
+│  │  }
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:108:19
+│  │      at buildContextBrain (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:125:7)
+│  │      at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.41.22_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/context/genContextBrain.js:36:16
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.8_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.2_rhach_ac3624c10954cad4552d1c75fbcb3100/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:170:19)
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r1._.given.by_peer.repo-rules.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r1._.given.by_peer.repo-rules.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 4
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 5,269
+│  │     │  └─ context: 0.5%
+│  │     └─ cost
+│  │        └─ estimate: $0.000885220
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-55-01-237Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-55-01-237Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-55-01-237Z/tokens.expected.md
+│  │        ├─ rules: .agent (2.0k, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 6,390
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 384
+│  │     │  └─ total: 6,774
+│  │     ├─ cost
+│  │     │  └─ total: $0.001002120
+│  │     └─ time
+│  │        └─ total: 5337ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-55-01-237Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r1._.given.by_peer.repo-rules.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r1._.given.by_peer.repo-rules.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r1._.given.by_peer.repo-rules.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T12-55-01-237Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r1._.given.by_peer.repo-rules.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 10
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 8,211
+│  │     │  └─ context: 0.8%
+│  │     └─ cost
+│  │        └─ estimate: $0.001379420
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-57-35-659Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-57-35-659Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-57-35-659Z/tokens.expected.md
+│  │        ├─ rules: .agent (657, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 9,273
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 4,058
+│  │     │  └─ total: 13,331
+│  │     ├─ cost
+│  │     │  └─ total: $0.002434460
+│  │     └─ time
+│  │        └─ total: 33285ms
+│  │  
+│  │  🦉 needs your talons
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-57-35-659Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r10._.given.by_peer.ergo-snapshot-visual-blemishes.report.md
+│  │     └─ summary
+│  │        ├─ 1 blocker 🔴
+│  │        └─ 0 nitpicks
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r10._.given.by_peer.ergo-snapshot-visual-blemishes.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r10._.given.by_peer.ergo-snapshot-visual-blemishes.report.md
@@ -1,0 +1,29 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T12-57-35-659Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r10._.given.by_peer.ergo-snapshot-visual-blemishes.report.md
+   └─ summary
+      ├─ 1 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Typo and inconsistent vibe in snapshot output pattern
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md
+
+**locations**:
+- .behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md
+
+In the output pattern for 'block --org @all success', the turtle message reads '🐢 groovy, bond fire time'. This contains a typo: 'bond fire' is likely intended as 'bonfire'. Additionally, 'groovy' is not among the established turtle vibe phrases (e.g., 'shell yeah', 'bummer dude', 'cowabunga'), creating inconsistency with other output patterns. This makes the snapshot output unclean and inconsistent, violating the rule forbidding visual blemishes.
+
+**snippet**:
+```markdown
+### block --org @all success
+
+```
+🐢 groovy, bond fire time
+
+🐚 git.commit.uses block --org @all
+   ├─ reset: all orgs → blocked
+   └─ @all: blocked
+```
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r2._.given.by_peer.mech-failhides.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r2._.given.by_peer.mech-failhides.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 11
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 6,083
+│  │     │  └─ context: 0.6%
+│  │     └─ cost
+│  │        └─ estimate: $0.001021860
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-55-07-479Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-55-07-479Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-55-07-479Z/tokens.expected.md
+│  │        ├─ rules: .agent (2.6k, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 7,175
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 1,104
+│  │     │  └─ total: 8,279
+│  │     ├─ cost
+│  │     │  └─ total: $0.001313620
+│  │     └─ time
+│  │        └─ total: 11618ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-55-07-479Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r2._.given.by_peer.mech-failhides.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r2._.given.by_peer.mech-failhides.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r2._.given.by_peer.mech-failhides.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T12-55-07-479Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r2._.given.by_peer.mech-failhides.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r3._.given.by_peer.mech-decode-friction.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r3._.given.by_peer.mech-decode-friction.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 1
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 4,491
+│  │     │  └─ context: 0.4%
+│  │     └─ cost
+│  │        └─ estimate: $0.000754460
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-55-20-052Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-55-20-052Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-55-20-052Z/tokens.expected.md
+│  │        ├─ rules: .agent (388, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 5,455
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 574
+│  │     │  └─ total: 6,029
+│  │     ├─ cost
+│  │     │  └─ total: $0.000924420
+│  │     └─ time
+│  │        └─ total: 25718ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-55-20-052Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r3._.given.by_peer.mech-decode-friction.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r3._.given.by_peer.mech-decode-friction.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r3._.given.by_peer.mech-decode-friction.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T12-55-20-052Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r3._.given.by_peer.mech-decode-friction.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r4._.given.by_peer.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r4._.given.by_peer.arch-opport-decomposition.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 28
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 19,399
+│  │     │  └─ context: 1.9%
+│  │     └─ cost
+│  │        └─ estimate: $0.003259060
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-55-47-162Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-55-47-162Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-55-47-162Z/tokens.expected.md
+│  │        ├─ rules: .agent (554, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 19,881
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 244
+│  │     │  └─ total: 20,125
+│  │     ├─ cost
+│  │     │  └─ total: $0.002851660
+│  │     └─ time
+│  │        └─ total: 7223ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-55-47-162Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r4._.given.by_peer.arch-opport-decomposition.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r4._.given.by_peer.arch-opport-decomposition.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r4._.given.by_peer.arch-opport-decomposition.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T12-55-47-162Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r4._.given.by_peer.arch-opport-decomposition.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r5._.given.by_peer.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r5._.given.by_peer.arch-smell-scopeleaks.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 28
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 19,295
+│  │     │  └─ context: 1.9%
+│  │     └─ cost
+│  │        └─ estimate: $0.003241700
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-55-56-515Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-55-56-515Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-55-56-515Z/tokens.expected.md
+│  │        ├─ rules: .agent (454, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 19,760
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 318
+│  │     │  └─ total: 20,078
+│  │     ├─ cost
+│  │     │  └─ total: $0.002855440
+│  │     └─ time
+│  │        └─ total: 29956ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-55-56-515Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r5._.given.by_peer.arch-smell-scopeleaks.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r5._.given.by_peer.arch-smell-scopeleaks.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r5._.given.by_peer.arch-smell-scopeleaks.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T12-55-56-515Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r5._.given.by_peer.arch-smell-scopeleaks.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r6._.given.by_peer.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r6._.given.by_peer.arch-hazards-maintenance.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 24
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 11,095
+│  │     │  └─ context: 1.1%
+│  │     └─ cost
+│  │        └─ estimate: $0.001864100
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-56-27-766Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-56-27-766Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-56-27-766Z/tokens.expected.md
+│  │        ├─ rules: .agent (506, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 12,124
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 760
+│  │     │  └─ total: 12,884
+│  │     ├─ cost
+│  │     │  └─ total: $0.001910160
+│  │     └─ time
+│  │        └─ total: 18498ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-56-27-766Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r6._.given.by_peer.arch-hazards-maintenance.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r6._.given.by_peer.arch-hazards-maintenance.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r6._.given.by_peer.arch-hazards-maintenance.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T12-56-27-766Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r6._.given.by_peer.arch-hazards-maintenance.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r7._.given.by_peer.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r7._.given.by_peer.arch-hazards-behavior.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 20
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 11,608
+│  │     │  └─ context: 1.2%
+│  │     └─ cost
+│  │        └─ estimate: $0.001950200
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-56-47-270Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-56-47-270Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-56-47-270Z/tokens.expected.md
+│  │        ├─ rules: .agent (985, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 12,382
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 260
+│  │     │  └─ total: 12,642
+│  │     ├─ cost
+│  │     │  └─ total: $0.001806280
+│  │     └─ time
+│  │        └─ total: 6502ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-56-47-270Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r7._.given.by_peer.arch-hazards-behavior.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r7._.given.by_peer.arch-hazards-behavior.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r7._.given.by_peer.arch-hazards-behavior.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T12-56-47-270Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r7._.given.by_peer.arch-hazards-behavior.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r8._.given.by_peer.arch-ambiguous-terms.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r8._.given.by_peer.arch-ambiguous-terms.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 15
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 8,451
+│  │     │  └─ context: 0.8%
+│  │     └─ cost
+│  │        └─ estimate: $0.001419740
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-56-55-549Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-56-55-549Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-56-55-549Z/tokens.expected.md
+│  │        ├─ rules: .agent (471, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 9,594
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 3,190
+│  │     │  └─ total: 12,784
+│  │     ├─ cost
+│  │     │  └─ total: $0.002236360
+│  │     └─ time
+│  │        └─ total: 21840ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-56-55-549Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r8._.given.by_peer.arch-ambiguous-terms.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r8._.given.by_peer.arch-ambiguous-terms.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r8._.given.by_peer.arch-ambiguous-terms.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T12-56-55-549Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r8._.given.by_peer.arch-ambiguous-terms.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 12
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 12,067
+│  │     │  └─ context: 1.2%
+│  │     └─ cost
+│  │        └─ estimate: $0.002027340
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T12-57-19-533Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T12-57-19-533Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T12-57-19-533Z/tokens.expected.md
+│  │        ├─ rules: .agent (495, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 12,687
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 3,640
+│  │     │  ├─ output: 649
+│  │     │  └─ total: 16,976
+│  │     ├─ cost
+│  │     │  └─ total: $0.001957900
+│  │     └─ time
+│  │        └─ total: 14614ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T12-57-19-533Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r9._.given.by_peer.ergo-acceptance-journey-coverage.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r9._.given.by_peer.ergo-acceptance-journey-coverage.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r9._.given.by_peer.ergo-acceptance-journey-coverage.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T12-57-19-533Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i2.7b17d6a2dc0fc07e88.r9._.given.by_peer.ergo-acceptance-journey-coverage.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r1._.given.by_peer.repo-rules.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r1._.given.by_peer.repo-rules.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 4
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 5,266
+│  │     │  └─ context: 0.5%
+│  │     └─ cost
+│  │        └─ estimate: $0.000884800
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-00-42-176Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-00-42-176Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-00-42-176Z/tokens.expected.md
+│  │        ├─ rules: .agent (2.0k, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 6,385
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 615
+│  │     │  └─ total: 7,000
+│  │     ├─ cost
+│  │     │  └─ total: $0.001066100
+│  │     └─ time
+│  │        └─ total: 39962ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-00-42-176Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r1._.given.by_peer.repo-rules.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r1._.given.by_peer.repo-rules.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r1._.given.by_peer.repo-rules.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-00-42-176Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r1._.given.by_peer.repo-rules.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r10._.given.by_peer.ergo-snapshot-visual-blemishes.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 10
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 8,208
+│  │     │  └─ context: 0.8%
+│  │     └─ cost
+│  │        └─ estimate: $0.001379000
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-04-12-137Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-04-12-137Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-04-12-137Z/tokens.expected.md
+│  │        ├─ rules: .agent (657, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 9,268
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 3,709
+│  │     │  └─ total: 12,977
+│  │     ├─ cost
+│  │     │  └─ total: $0.002336040
+│  │     └─ time
+│  │        └─ total: 24749ms
+│  │  
+│  │  🦉 just a few hoots
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-04-12-137Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r10._.given.by_peer.ergo-snapshot-visual-blemishes.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        └─ 1 nitpick 🟠
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r10._.given.by_peer.ergo-snapshot-visual-blemishes.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r10._.given.by_peer.ergo-snapshot-visual-blemishes.report.md
@@ -1,0 +1,30 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-04-12-137Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r10._.given.by_peer.ergo-snapshot-visual-blemishes.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 1 nitpicks 🟠
+
+---
+# nitpick.1: missing apostrophe in status phrase
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md
+
+**locations**:
+- .behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md
+
+the status phrase 'lets check the meter...' is missing an apostrophe in 'lets' (should be 'let's'). this is a minor visual blemish that reduces clarity and consistency with the seaturtle vibe (which uses apostrophes in similar phrases like 'let's dive in').
+
+**snippet**:
+```markdown
+### get --org output
+
+```
+🐢 lets check the meter...
+
+🐚 git.commit.uses get --org
+   ├─ @all: blocked
+   ├─ ehmpathy: allowed
+   └─ ahbode: allowed
+```
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r11._.given.by_peer.enroll-blueprint-arch-defects.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r11._.given.by_peer.enroll-blueprint-arch-defects.md
@@ -1,0 +1,162 @@
+├─ stdout
+│  ├─
+│  │
+│  │  Here's the architectural review of the blueprint:
+│  │  
+│  │  ---
+│  │  
+│  │  ## architectural review: `3.3.1.blueprint.product.yield.md`
+│  │  
+│  │  ### 🔴 blocker 1 — `@all reset` stores redundant entries (state pollution + confusing `get --org`)
+│  │  
+│  │  **location**: blueprint codepath tree → `git.commit.uses.org.sh` → `allow/@all` + `block/@all`
+│  │  
+│  │  **defect**: the blueprint specifies `@all reset` as:
+│  │  > "1. reset: set ALL orgs to 'blocked'; 2. default: set @all to 'blocked'"
+│  │  
+│  │  this produces a state file like:
+│  │  ```jsonc
+│  │  { "orgs": { "@all": "blocked", "ehmpathy": "blocked", "ahbode": "blocked" } }
+│  │  ```
+│  │  
+│  │  `ehmpathy: blocked` and `ahbode: blocked` are **redundant** — `@all: blocked` already covers them via the effective state algorithm. the entries add noise forever. worse, `get --org` would output redundant rows that imply explicit overrides where none exist.
+│  │  
+│  │  **correct semantics** (matches `radio.uses.org.sh` reference pattern too):
+│  │  - `block --org @all` → delete all individual org entries, set `@all: blocked`
+│  │  - `allow --org @all` → delete all individual org entries, set `@all: allowed`
+│  │  - result: only meaningful overrides exist in state; `get --org` shows only explicit distinctions
+│  │  
+│  │  **impact**: state file grows unboundedly; `get --org` shows noise vs signal; `get --org ehmpathy` would show `ehmpathy: blocked (explicit)` when it's actually `(from @all)` — misleading
+│  │  
+│  │  **fix**: revise `@all` codepath to clear all individual entries before writing new `@all` value.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🔴 blocker 2 — `check_org_blocker()` return signature mismatch
+│  │  
+│  │  **location**: blueprint codepath tree → `git.commit.operations.sh` → `check_org_blocker()`
+│  │  
+│  │  **defect**: blueprint says `check_org_blocker()` "returns blocked/allowed/unset" — a **string return**. but the calling site in `git.commit.set.sh` uses:
+│  │  ```bash
+│  │  check_global_blocker || exit 2
+│  │  check_org_blocker || exit 2     # ← this pattern requires exit codes, not strings
+│  │  ```
+│  │  
+│  │  `check_global_blocker()` uses exit codes (0 = not blocked, 2 = blocked) + sets `GLOBAL_BLOCK_REASON`. `check_org_blocker()` must follow the same pattern. the "unset" state (when both `@all` and the org are unset) needs a **distinct error message** from "blocked" but must also exit 2 — this is not expressible as just a return code. it requires `ORG_BLOCK_REASON` env var or equivalent.
+│  │  
+│  │  **impact**: if implemented as string-return, `check_org_blocker || exit 2` will always pass (bash strings are truthy), silently skipping the org check — a silent security gap.
+│  │  
+│  │  **fix**: revise `check_org_blocker()` signature to match `check_global_blocker()`:
+│  │  - exit 0 = allowed (continue)
+│  │  - exit 2 = blocked or unset (halt)
+│  │  - sets `ORG_BLOCK_REASON` with specific message ("org blocked" vs "org unset, failfast required")
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🔴 blocker 3 — `get_org_from_keyrack()` placed in wrong domain file
+│  │  
+│  │  **location**: blueprint filediff tree → `git.commit.operations.sh` (proposed `[+] get_org_from_keyrack()`)
+│  │  
+│  │  **defect**: `git.commit.operations.sh` is a git behavioral commit operations file (behavioral commits, ancestor branch detection, global blocker check). reading `.agent/keyrack.yml` is a **keyrack domain concern**, not a git commit concern.
+│  │  
+│  │  critically: `keyrack.operations.sh` already exists in the same directory and handles keyrack reads (`fetch_github_token()`). placing `get_org_from_keyrack()` in `git.commit.operations.sh` creates a mixed-responsibility file and misses the obvious placement.
+│  │  
+│  │  **impact**: `git.commit.operations.sh` now has 3 unrelated domains (git history, global blocker, keyrack reads). `get_org_from_keyrack()` is not discoverable to future engineers looking for keyrack operations. violates bounded contexts.
+│  │  
+│  │  **fix**: move `get_org_from_keyrack()` to `keyrack.operations.sh`. update blueprint filediff/codepath accordingly (`[~] keyrack.operations.sh`).
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🔴 blocker 4 — `del --org @all` behavior undefined (behavior hazard)
+│  │  
+│  │  **location**: blueprint codepath tree → `git.commit.uses.org.sh` → `del` subcommand
+│  │  
+│  │  **defect**: blueprint only covers `del --org $specific_org` — "remove org entry, defer to @all". it says nothing about `del --org @all`.
+│  │  
+│  │  if a human runs `del --org @all`, the `@all` key is deleted from the state file. all subsequent commits will hit the "unset" failfast condition — **every commit silently breaks** until a human notices and sets `@all` again.
+│  │  
+│  │  **impact**: behavior hazard — `del --org @all` is a footgun with no protection or clear semantics.
+│  │  
+│  │  **fix**: explicitly handle in codepath tree:
+│  │  - option A: `del --org @all` → error: "cannot del @all; use allow or block --org @all"
+│  │  - option B: `del --org @all` → clears entire state file (full reset), with explicit warning output
+│  │  
+│  │  add test case: `given: human runs del --org @all → then: clear error or explicit semantics`.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🔴 blocker 5 — `--org` optional-value parsing unspecified in dispatcher
+│  │  
+│  │  **location**: blueprint codepath tree → `git.commit.uses.sh` → `[~] arg parse` → `[+] --org flag detection`
+│  │  
+│  │  **defect**: the dispatcher currently strips `--global` and passes remaining args through. adding `--org` introduces an **optional-value flag**:
+│  │  - `git.commit.uses get --org` → `--org` has no value (show all)
+│  │  - `git.commit.uses get --org ehmpathy` → `--org` has value `ehmpathy`
+│  │  
+│  │  the blueprint shows `[+] --org flag detection` but doesn't specify how the dispatcher extracts the optional value. naive `--global`-style detection (just check for presence of `--org`) would strip `--org` and lose the org value before dispatch.
+│  │  
+│  │  **impact**: `git.commit.uses.org.sh` would receive args without the org name, making `get --org ehmpathy` behave like `get --org` — wrong org resolution.
+│  │  
+│  │  **fix**: specify in dispatcher codepath how `--org` with optional value is extracted and forwarded. example: detect `--org` presence for dispatch decision, but pass `--org <value>` through to `git.commit.uses.org.sh` intact (don't strip it like `--global`).
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🟡 nitpick 1 — test coverage gap: `get --org` when no state file exists
+│  │  
+│  │  **location**: blueprint test tree → `git.commit.uses.integration.test.ts` → case26
+│  │  
+│  │  **gap**: case26 tests `get --org` starting from `@all: blocked, ehmpathy: allowed` state. but what does `get --org` output when there's no state file at all? the blueprint's effective state algorithm would failfast on any specific org lookup, but `get --org` with no args has no specific org to fail on.
+│  │  
+│  │  **impact**: undefined output for first-time users who haven't configured any org state yet.
+│  │  
+│  │  **fix**: add `[case_N] get --org when no state configured`:
+│  │  ```
+│  │  given: no .org.jsonc file exists
+│  │    when: human runs get --org
+│  │      then: output shows "(no org config; run block --org @all to configure)"
+│  │      then: exit 0 (not an error, just informational)
+│  │  ```
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🟡 nitpick 2 — `@all reset` output format redundant post-fix
+│  │  
+│  │  after fixing blocker 1 (clear-not-reset semantics), the output pattern for `block --org @all` in the blueprint should be revised:
+│  │  
+│  │  current blueprint output:
+│  │  ```
+│  │  🐚 git.commit.uses block --org @all
+│  │     ├─ reset: all orgs → blocked
+│  │     └─ @all: blocked
+│  │  ```
+│  │  
+│  │  with clean semantics, there are no individual org entries to show as "reset" — the output should read:
+│  │  ```
+│  │  🐚 git.commit.uses block --org @all
+│  │     ├─ cleared: all org overrides removed
+│  │     └─ @all: blocked (default for all orgs)
+│  │  ```
+│  │  
+│  │  this better communicates the actual state: `@all` is now the sole source of truth, and any prior overrides are gone.
+│  │  
+│  │  ---
+│  │  
+│  │  ### summary
+│  │  
+│  │  | # | severity | issue | fix |
+│  │  |---|----------|-------|-----|
+│  │  | 1 | 🔴 blocker | `@all reset` stores redundant entries → state pollution | clear individual entries, don't reset them |
+│  │  | 2 | 🔴 blocker | `check_org_blocker()` return signature mismatch with `check_global_blocker()` | use exit code pattern + `ORG_BLOCK_REASON` var |
+│  │  | 3 | 🔴 blocker | `get_org_from_keyrack()` placed in wrong domain file | move to `keyrack.operations.sh` |
+│  │  | 4 | 🔴 blocker | `del --org @all` undefined behavior | explicit error or clear semantics + test |
+│  │  | 5 | 🔴 blocker | `--org` optional-value parsing unspecified in dispatcher | specify how value is extracted and forwarded |
+│  │  | 6 | 🟡 nitpick | `get --org` when no state file — missing test + output | add test + informational output |
+│  │  | 7 | 🟡 nitpick | output for `@all reset` implies individual entries exist | revise after blocker 1 fix |
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  Warning: no stdin data received in 3s, proceeding without it. If piping from a slow command, redirect stdin explicitly: < /dev/null to skip, or wait longer.
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r12._.given.by_peer.enroll-blueprint-behavior-intent.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r12._.given.by_peer.enroll-blueprint-behavior-intent.md
@@ -1,0 +1,154 @@
+├─ stdout
+│  ├─
+│  │
+│  │  Now I have a thorough picture. Here is the review:
+│  │  
+│  │  ---
+│  │  
+│  │  ## blueprint review: `git.commit.uses --org`
+│  │  
+│  │  overall: solid foundation — the criteria and matrix coverage are comprehensive, and the journey test is a good anchor. but there are **4 blockers and 4 gaps** that need to be addressed before implementation.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🔴 blocker.1 — `git.commit.set.sh` missing from filediff tree
+│  │  
+│  │  the codepath tree shows:
+│  │  ```
+│  │  git.commit.set.sh (precedence integration)
+│  │  ├── [~] precedence check order
+│  │  │   ├── [○] check_global_blocker || exit 2
+│  │  │   ├── [+] check_org_blocker || exit 2
+│  │  │   └── [○] check_local_quota || exit 2
+│  │  ```
+│  │  
+│  │  but the filediff tree omits `git.commit.set.sh` entirely. a mechanic implementing against the filediff tree would never touch it. the org blocker would never fire.
+│  │  
+│  │  **fix**: add `[~] git.commit.set.sh` to the filediff tree.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🔴 blocker.2 — no output pattern when `git.commit.set` is org-blocked
+│  │  
+│  │  the output patterns section covers `allow`, `block --org @all`, `get --org`, `typo`, and `keyrack failfast`. but it never specifies what the user sees when they try to **actually commit** and the org blocker fires.
+│  │  
+│  │  this is the most common friction path — the mechanic attempts a commit and gets blocked. without a specified output pattern, the builder will freestyle it. example of what's missing:
+│  │  
+│  │  ```
+│  │  🐢 bummer dude...
+│  │  
+│  │  🐚 git.commit.set
+│  │     └─ error: org blocked (org: ahbode, blocked by: @all)
+│  │     └─ hint: run 'rhx git.commit.uses allow --org ahbode' to unblock
+│  │  ```
+│  │  
+│  │  **fix**: add output pattern for "commit blocked due to org blocker" with hint for resolution. this should also be snapped in the test tree.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🔴 blocker.3 — no test coverage for `git.commit.set.sh` + org blocker integration
+│  │  
+│  │  the test tree only modifies `git.commit.uses.integration.test.ts` and adds `git.commit.operations.integration.test.ts`. there is no test that exercises the actual commit flow being blocked by `check_org_blocker()`.
+│  │  
+│  │  the journey case [case33][t0] (`initial: no org config → commit blocked`) is the closest thing, but it's in the `uses` test, not a commit flow test. [case31] tests precedence but it's unclear whether it's testing `git.commit.set` or only `git.commit.uses`.
+│  │  
+│  │  **fix**: the filediff tree should include `[~] git.commit.set.integration.test.ts` with cases that test: (a) org blocked → commit fails with correct output, (b) org allowed + local quota → commit succeeds.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🔴 blocker.4 — `del --org @all` behavior is undefined
+│  │  
+│  │  the blueprint specifies `del --org $org` removes a specific org entry so it inherits from `@all`. but what does `del --org @all` do? @all has nothing to inherit from — if it's removed, the matrix says `| unset | unset | unset (failfast) |`.
+│  │  
+│  │  this is a footgun: `del --org @all` would silently drop all org policy and cause every commit to failfast with "org unset". should it be forbidden? should it warn?
+│  │  
+│  │  **fix**: specify in the blueprint whether `del --org @all` is (a) forbidden with a clear error, or (b) allowed with explicit warning about the failfast consequence. add a test case for it.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🟡 gap.1 — combined `--org @all --global` from wish is dropped without explanation
+│  │  
+│  │  the wish describes this workflow:
+│  │  ```sh
+│  │  rhx git.commit.uses block --org @all --global
+│  │  rhx git.commit.uses allow --global
+│  │  rhx git.commit.uses allow --org $org
+│  │  ```
+│  │  
+│  │  the combined `--org @all --global` flag is not addressed anywhere in the vision or blueprint. the dispatcher routes to EITHER `org.sh` OR `global.sh` — not both. so this combined invocation would be silently ignored or error.
+│  │  
+│  │  the vision simplified this to just `block --org @all` + `allow --org ehmpathy` without explaining why the `--global` step was dropped. if intentional, document it.
+│  │  
+│  │  **fix**: either (a) support `--org --global` combined dispatch, or (b) explicitly state in the vision/blueprint that this workflow is simplified to: `block --org @all`, then `allow --org ehmpathy` — no need to touch global.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🟡 gap.2 — no output pattern for `get --org` in uninitialized state
+│  │  
+│  │  when the org state file doesn't exist yet (first invocation), what does `get --org` show? the `radio.uses.org` reference returns `{ "orgs": {} }` when file is absent, which would render as an empty list. is that helpful?
+│  │  
+│  │  the vision criteria does not cover this case, and neither does the test tree. a human running `get --org` before any policy is configured needs to understand the current state.
+│  │  
+│  │  **fix**: add an output pattern for the uninitialized state (e.g., `no org policy configured`) and add a test case in [case26] for this initial condition.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🟡 gap.3 — acceptance tests not in test tree despite coverage matrix saying they're needed
+│  │  
+│  │  the coverage matrix states:
+│  │  ```
+│  │  | contract | git.commit.uses --org | integration + acceptance tests |
+│  │  ```
+│  │  
+│  │  but the test tree only shows `integration.test.ts` files — no `.acceptance.test.ts`. if these integration tests ARE the acceptance tests (because they run the real shell scripts end-to-end), the naming is misleading and the filediff tree comment should clarify this.
+│  │  
+│  │  the blueprint guard explicitly calls out: "acceptance tests MUST snapshot contract stdouts — exhaustive for positive and negative cases". this requires clarity on whether the integration tests satisfy that requirement or if separate acceptance tests are needed.
+│  │  
+│  │  **fix**: either add `.acceptance.test.ts` files to the test tree, or explicitly annotate the integration tests as serving the acceptance role and confirm they include `toMatchSnapshot()` for all stdout paths.
+│  │  
+│  │  ---
+│  │  
+│  │  ### 🟡 gap.4 — `@all reset` output is misleading when there are no prior orgs
+│  │  
+│  │  the output pattern for `block --org @all`:
+│  │  ```
+│  │  🐚 git.commit.uses block --org @all
+│  │     ├─ reset: all orgs → blocked
+│  │     └─ @all: blocked
+│  │  ```
+│  │  
+│  │  the `reset: all orgs → blocked` line implies orgs were reset. but on first invocation (no prior orgs), there's nothing to reset. showing this line would be misleading.
+│  │  
+│  │  **fix**: specify conditional output — show the reset line only if prior org entries were cleared, otherwise show just `@all: blocked`. add a test case for `block --org @all` with no prior orgs set.
+│  │  
+│  │  ---
+│  │  
+│  │  ### nitpick — `git.commit.operations.integration.test.ts` only covers the positive path
+│  │  
+│  │  `[case32]` tests `get_org_from_keyrack` with valid keyrack.yml only. the failfast cases (keyrack absent, org field unset) are tested in [case30] of the uses test, but as a **communicator**, `get_org_from_keyrack()` should have its own failfast test coverage in the operations test.
+│  │  
+│  │  **fix** (nitpick, not blocker): add `[t2]` and `[t3]` to [case32] for failfast paths in the operations integration test.
+│  │  
+│  │  ---
+│  │  
+│  │  ### summary table
+│  │  
+│  │  | # | severity | issue |
+│  │  |---|----------|-------|
+│  │  | 1 | blocker | `git.commit.set.sh` missing from filediff tree |
+│  │  | 2 | blocker | no output pattern for commit-blocked-by-org error |
+│  │  | 3 | blocker | no test coverage for `git.commit.set.sh` + org blocker integration |
+│  │  | 4 | blocker | `del --org @all` behavior undefined (footgun) |
+│  │  | 5 | gap | combined `--org --global` from wish dropped without explanation |
+│  │  | 6 | gap | `get --org` in uninitialized state not specified |
+│  │  | 7 | gap | acceptance tests absent from test tree despite coverage matrix |
+│  │  | 8 | gap | `@all reset` output misleads when no prior orgs exist |
+│  │  | 9 | nitpick | operations integration test missing failfast paths for `get_org_from_keyrack` |
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  Warning: no stdin data received in 3s, proceeding without it. If piping from a slow command, redirect stdin explicitly: < /dev/null to skip, or wait longer.
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r2._.given.by_peer.mech-failhides.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r2._.given.by_peer.mech-failhides.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 11
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 6,080
+│  │     │  └─ context: 0.6%
+│  │     └─ cost
+│  │        └─ estimate: $0.001021440
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-01-23-081Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-01-23-081Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-01-23-081Z/tokens.expected.md
+│  │        ├─ rules: .agent (2.6k, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 7,170
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 633
+│  │     │  └─ total: 7,803
+│  │     ├─ cost
+│  │     │  └─ total: $0.001181040
+│  │     └─ time
+│  │        └─ total: 8554ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-01-23-081Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r2._.given.by_peer.mech-failhides.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r2._.given.by_peer.mech-failhides.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r2._.given.by_peer.mech-failhides.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-01-23-081Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r2._.given.by_peer.mech-failhides.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r3._.given.by_peer.mech-decode-friction.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r3._.given.by_peer.mech-decode-friction.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 1
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 4,488
+│  │     │  └─ context: 0.4%
+│  │     └─ cost
+│  │        └─ estimate: $0.000754040
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-01-32-542Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-01-32-542Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-01-32-542Z/tokens.expected.md
+│  │        ├─ rules: .agent (388, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 5,450
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 503
+│  │     │  └─ total: 5,953
+│  │     ├─ cost
+│  │     │  └─ total: $0.000903840
+│  │     └─ time
+│  │        └─ total: 8942ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-01-32-542Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r3._.given.by_peer.mech-decode-friction.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r3._.given.by_peer.mech-decode-friction.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r3._.given.by_peer.mech-decode-friction.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-01-32-542Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r3._.given.by_peer.mech-decode-friction.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r4._.given.by_peer.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r4._.given.by_peer.arch-opport-decomposition.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 28
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 19,396
+│  │     │  └─ context: 1.9%
+│  │     └─ cost
+│  │        └─ estimate: $0.003258640
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-01-42-306Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-01-42-306Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-01-42-306Z/tokens.expected.md
+│  │        ├─ rules: .agent (554, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 19,876
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 10,835
+│  │     │  ├─ output: 1,578
+│  │     │  └─ total: 32,289
+│  │     ├─ cost
+│  │     │  └─ total: $0.003224480
+│  │     └─ time
+│  │        └─ total: 21029ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-01-42-306Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r4._.given.by_peer.arch-opport-decomposition.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r4._.given.by_peer.arch-opport-decomposition.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r4._.given.by_peer.arch-opport-decomposition.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-01-42-306Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r4._.given.by_peer.arch-opport-decomposition.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r5._.given.by_peer.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r5._.given.by_peer.arch-smell-scopeleaks.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 28
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 19,292
+│  │     │  └─ context: 1.9%
+│  │     └─ cost
+│  │        └─ estimate: $0.003241000
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-02-04-343Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-02-04-343Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-02-04-343Z/tokens.expected.md
+│  │        ├─ rules: .agent (454, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 19,755
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 13,629
+│  │     │  ├─ output: 379
+│  │     │  └─ total: 33,763
+│  │     ├─ cost
+│  │     │  └─ total: $0.002871820
+│  │     └─ time
+│  │        └─ total: 9144ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-02-04-343Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r5._.given.by_peer.arch-smell-scopeleaks.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r5._.given.by_peer.arch-smell-scopeleaks.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r5._.given.by_peer.arch-smell-scopeleaks.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-02-04-343Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r5._.given.by_peer.arch-smell-scopeleaks.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r6._.given.by_peer.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r6._.given.by_peer.arch-hazards-maintenance.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 24
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 11,092
+│  │     │  └─ context: 1.1%
+│  │     └─ cost
+│  │        └─ estimate: $0.001863400
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-02-14-364Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-02-14-364Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-02-14-364Z/tokens.expected.md
+│  │        ├─ rules: .agent (506, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 12,119
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 947
+│  │     │  └─ total: 13,066
+│  │     ├─ cost
+│  │     │  └─ total: $0.001961820
+│  │     └─ time
+│  │        └─ total: 9228ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-02-14-364Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r6._.given.by_peer.arch-hazards-maintenance.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r6._.given.by_peer.arch-hazards-maintenance.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r6._.given.by_peer.arch-hazards-maintenance.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-02-14-364Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r6._.given.by_peer.arch-hazards-maintenance.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r7._.given.by_peer.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r7._.given.by_peer.arch-hazards-behavior.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 20
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 11,605
+│  │     │  └─ context: 1.2%
+│  │     └─ cost
+│  │        └─ estimate: $0.001949780
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-02-24-507Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-02-24-507Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-02-24-507Z/tokens.expected.md
+│  │        ├─ rules: .agent (985, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 12,377
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 6,251
+│  │     │  ├─ output: 2,163
+│  │     │  └─ total: 20,791
+│  │     ├─ cost
+│  │     │  └─ total: $0.002338420
+│  │     └─ time
+│  │        └─ total: 28854ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-02-24-507Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r7._.given.by_peer.arch-hazards-behavior.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r7._.given.by_peer.arch-hazards-behavior.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r7._.given.by_peer.arch-hazards-behavior.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-02-24-507Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r7._.given.by_peer.arch-hazards-behavior.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r8._.given.by_peer.arch-ambiguous-terms.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r8._.given.by_peer.arch-ambiguous-terms.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 15
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 8,448
+│  │     │  └─ context: 0.8%
+│  │     └─ cost
+│  │        └─ estimate: $0.001419320
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-02-54-293Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-02-54-293Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-02-54-293Z/tokens.expected.md
+│  │        ├─ rules: .agent (471, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 9,589
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 3,258
+│  │     │  └─ total: 12,847
+│  │     ├─ cost
+│  │     │  └─ total: $0.002254700
+│  │     └─ time
+│  │        └─ total: 36830ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-02-54-293Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r8._.given.by_peer.arch-ambiguous-terms.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r8._.given.by_peer.arch-ambiguous-terms.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r8._.given.by_peer.arch-ambiguous-terms.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-02-54-293Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r8._.given.by_peer.arch-ambiguous-terms.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r9._.given.by_peer.ergo-acceptance-journey-coverage.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: .behavior/v2026_06_22.git-commit-uses-grain/3.3.*.blueprint.*.md
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 12
+│  │     │  └─ targets: 1
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 12,064
+│  │     │  └─ context: 1.2%
+│  │     └─ cost
+│  │        └─ estimate: $0.002026640
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T13-03-32-936Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T13-03-32-936Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T13-03-32-936Z/tokens.expected.md
+│  │        ├─ rules: .agent (495, 100%)
+│  │        └─ targets: .behavior (2.5k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 12,682
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 6,556
+│  │     │  ├─ output: 673
+│  │     │  └─ total: 19,911
+│  │     ├─ cost
+│  │     │  └─ total: $0.001963920
+│  │     └─ time
+│  │        └─ total: 37762ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T13-03-32-936Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r9._.given.by_peer.ergo-acceptance-journey-coverage.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r9._.given.by_peer.ergo-acceptance-journey-coverage.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r9._.given.by_peer.ergo-acceptance-journey-coverage.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T13-03-32-936Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/3.3.1.blueprint.product._.review.i3.1f3a5f33204fc50ef0.r9._.given.by_peer.ergo-acceptance-journey-coverage.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r1._.given.by_peer.repo-rules.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r1._.given.by_peer.repo-rules.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r2._.given.by_peer.mech-failhides.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r2._.given.by_peer.mech-failhides.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r3._.given.by_peer.mech-decode-friction.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r3._.given.by_peer.mech-decode-friction.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r4._.given.by_peer.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r4._.given.by_peer.arch-opport-decomposition.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/systemd-private-864bc1554a0b4ebc8e0879f7cd385f76-ModemManager.service-LkLb4X'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/systemd-private-864bc1554a0b4ebc8e0879f7cd385f76-ModemManager.service-LkLb4X'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r5._.given.by_peer.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r5._.given.by_peer.arch-smell-scopeleaks.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r6._.given.by_peer.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r6._.given.by_peer.arch-hazards-maintenance.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r7._.given.by_peer.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r7._.given.by_peer.arch-hazards-behavior.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r8._.given.by_peer.behavior-intent-coverage.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r8._.given.by_peer.behavior-intent-coverage.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r9._.given.by_peer.ergo-friction-hazards.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i1.ce6d43b8a997b97bbc.r9._.given.by_peer.ergo-friction-hazards.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r1._.given.by_peer.repo-rules.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r1._.given.by_peer.repo-rules.md
@@ -1,0 +1,72 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 4
+│  │     │  └─ targets: 2
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 14,482
+│  │     │  └─ context: 1.4%
+│  │     └─ cost
+│  │        └─ estimate: $0.002432920
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T14-21-44-357Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T14-21-44-357Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T14-21-44-357Z/tokens.expected.md
+│  │        ├─ rules: .agent (2.0k, 100%)
+│  │        └─ targets: src (11.7k, 100%)
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68
+│  │          return new APIError(status, error, message, headers);
+│  │                 ^
+│  │  
+│  │  APIError: 412 Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.
+│  │      at APIError.generate (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68:16)
+│  │      at OpenAI.makeStatusError (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:158:32)
+│  │      at OpenAI.makeRequest (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:301:30)
+│  │      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+│  │      at async BrainAtom.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-brains-fireworksai@0.1.3_rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensor_8570e921314347f094d9e4f8dc2954da/node_modules/rhachet-brains-fireworksai/dist/domain.operations/atom/genBrainAtom.js:124:30)
+│  │      at async Object.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/brain/asBrainAtomWithContextBound.js:20:24)
+│  │      at async Object.operation (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:546:32)
+│  │      at async withSpinner (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:116:28)
+│  │      at async stepReview (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:544:26)
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:177:9) {
+│  │    status: 412,
+│  │    headers: Headers {},
+│  │    requestID: 'chatcmpl-9d55ea9ab6bd43e9836361e51a93e7e3',
+│  │    error: {
+│  │      message: 'Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.',
+│  │      param: null,
+│  │      code: 'PRECONDITION_FAILED',
+│  │      type: 'error'
+│  │    },
+│  │    code: 'PRECONDITION_FAILED',
+│  │    param: null,
+│  │    type: 'error'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r2._.given.by_peer.mech-failhides.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r2._.given.by_peer.mech-failhides.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 11
+│  │     │  └─ targets: 2
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 15,296
+│  │     │  └─ context: 1.5%
+│  │     └─ cost
+│  │        └─ estimate: $0.002569840
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T14-21-45-494Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T14-21-45-494Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T14-21-45-494Z/tokens.expected.md
+│  │        ├─ rules: .agent (2.6k, 100%)
+│  │        └─ targets: src (11.7k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 15,888
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 1,608
+│  │     │  └─ total: 17,496
+│  │     ├─ cost
+│  │     │  └─ total: $0.002674560
+│  │     └─ time
+│  │        └─ total: 15992ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T14-21-45-494Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r2._.given.by_peer.mech-failhides.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r2._.given.by_peer.mech-failhides.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r2._.given.by_peer.mech-failhides.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T14-21-45-494Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r2._.given.by_peer.mech-failhides.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r3._.given.by_peer.mech-decode-friction.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r3._.given.by_peer.mech-decode-friction.md
@@ -1,0 +1,73 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 1
+│  │     │  └─ targets: 2
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 13,704
+│  │     │  └─ context: 1.4%
+│  │     └─ cost
+│  │        └─ estimate: $0.002302160
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T14-22-02-204Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T14-22-02-204Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T14-22-02-204Z/tokens.expected.md
+│  │        ├─ rules: .agent (388, 100%)
+│  │        └─ targets: src (11.7k, 100%)
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68
+│  │          return new APIError(status, error, message, headers);
+│  │                 ^
+│  │  
+│  │  APIError: 412 Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.
+│  │      at APIError.generate (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68:16)
+│  │      at OpenAI.makeStatusError (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:158:32)
+│  │      at OpenAI.makeRequest (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:301:30)
+│  │      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+│  │      at async BrainAtom.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-brains-fireworksai@0.1.3_rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensor_8570e921314347f094d9e4f8dc2954da/node_modules/rhachet-brains-fireworksai/dist/domain.operations/atom/genBrainAtom.js:124:30)
+│  │      at async Object.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/brain/asBrainAtomWithContextBound.js:20:24)
+│  │      at async Object.operation (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:546:32)
+│  │      at async withSpinner (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:116:28)
+│  │      at async stepReview (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:544:26)
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:177:9) {
+│  │    status: 412,
+│  │    headers: Headers {},
+│  │    requestID: 'chatcmpl-5bedf7f82d834acca0648e00c43c9940',
+│  │    error: {
+│  │      message: 'Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.',
+│  │      param: null,
+│  │      code: 'PRECONDITION_FAILED',
+│  │      type: 'error'
+│  │    },
+│  │    code: 'PRECONDITION_FAILED',
+│  │    param: null,
+│  │    type: 'error'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r4._.given.by_peer.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r4._.given.by_peer.arch-opport-decomposition.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 28
+│  │     │  └─ targets: 2
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 28,612
+│  │     │  └─ context: 2.9%
+│  │     └─ cost
+│  │        └─ estimate: $0.004806760
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T14-22-03-364Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T14-22-03-364Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T14-22-03-364Z/tokens.expected.md
+│  │        ├─ rules: .agent (554, 100%)
+│  │        └─ targets: src (11.7k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 28,594
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 472
+│  │     │  └─ total: 29,066
+│  │     ├─ cost
+│  │     │  └─ total: $0.004135320
+│  │     └─ time
+│  │        └─ total: 12000ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T14-22-03-364Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r4._.given.by_peer.arch-opport-decomposition.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r4._.given.by_peer.arch-opport-decomposition.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r4._.given.by_peer.arch-opport-decomposition.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T14-22-03-364Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r4._.given.by_peer.arch-opport-decomposition.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r5._.given.by_peer.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r5._.given.by_peer.arch-smell-scopeleaks.md
@@ -1,0 +1,73 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 28
+│  │     │  └─ targets: 2
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 28,508
+│  │     │  └─ context: 2.9%
+│  │     └─ cost
+│  │        └─ estimate: $0.004789400
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T14-22-16-105Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T14-22-16-105Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T14-22-16-105Z/tokens.expected.md
+│  │        ├─ rules: .agent (454, 100%)
+│  │        └─ targets: src (11.7k, 100%)
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68
+│  │          return new APIError(status, error, message, headers);
+│  │                 ^
+│  │  
+│  │  APIError: 412 Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.
+│  │      at APIError.generate (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68:16)
+│  │      at OpenAI.makeStatusError (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:158:32)
+│  │      at OpenAI.makeRequest (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:301:30)
+│  │      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+│  │      at async BrainAtom.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-brains-fireworksai@0.1.3_rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensor_8570e921314347f094d9e4f8dc2954da/node_modules/rhachet-brains-fireworksai/dist/domain.operations/atom/genBrainAtom.js:124:30)
+│  │      at async Object.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/brain/asBrainAtomWithContextBound.js:20:24)
+│  │      at async Object.operation (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:546:32)
+│  │      at async withSpinner (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:116:28)
+│  │      at async stepReview (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:544:26)
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:177:9) {
+│  │    status: 412,
+│  │    headers: Headers {},
+│  │    requestID: 'chatcmpl-174682bf2a6a449cb4f37be2531be6b0',
+│  │    error: {
+│  │      message: 'Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.',
+│  │      param: null,
+│  │      code: 'PRECONDITION_FAILED',
+│  │      type: 'error'
+│  │    },
+│  │    code: 'PRECONDITION_FAILED',
+│  │    param: null,
+│  │    type: 'error'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r6._.given.by_peer.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r6._.given.by_peer.arch-hazards-maintenance.md
@@ -1,0 +1,73 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 24
+│  │     │  └─ targets: 2
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 20,307
+│  │     │  └─ context: 2.0%
+│  │     └─ cost
+│  │        └─ estimate: $0.003411660
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T14-22-17-245Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T14-22-17-245Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T14-22-17-245Z/tokens.expected.md
+│  │        ├─ rules: .agent (506, 100%)
+│  │        └─ targets: src (11.7k, 100%)
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68
+│  │          return new APIError(status, error, message, headers);
+│  │                 ^
+│  │  
+│  │  APIError: 412 Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.
+│  │      at APIError.generate (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68:16)
+│  │      at OpenAI.makeStatusError (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:158:32)
+│  │      at OpenAI.makeRequest (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:301:30)
+│  │      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+│  │      at async BrainAtom.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-brains-fireworksai@0.1.3_rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensor_8570e921314347f094d9e4f8dc2954da/node_modules/rhachet-brains-fireworksai/dist/domain.operations/atom/genBrainAtom.js:124:30)
+│  │      at async Object.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/brain/asBrainAtomWithContextBound.js:20:24)
+│  │      at async Object.operation (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:546:32)
+│  │      at async withSpinner (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:116:28)
+│  │      at async stepReview (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:544:26)
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:177:9) {
+│  │    status: 412,
+│  │    headers: Headers {},
+│  │    requestID: 'chatcmpl-4681cdf527f3402d9c53cf6fe5d26e65',
+│  │    error: {
+│  │      message: 'Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.',
+│  │      param: null,
+│  │      code: 'PRECONDITION_FAILED',
+│  │      type: 'error'
+│  │    },
+│  │    code: 'PRECONDITION_FAILED',
+│  │    param: null,
+│  │    type: 'error'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r7._.given.by_peer.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r7._.given.by_peer.arch-hazards-behavior.md
@@ -1,0 +1,73 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 20
+│  │     │  └─ targets: 2
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 20,820
+│  │     │  └─ context: 2.1%
+│  │     └─ cost
+│  │        └─ estimate: $0.003497760
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T14-22-18-331Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T14-22-18-331Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T14-22-18-331Z/tokens.expected.md
+│  │        ├─ rules: .agent (985, 100%)
+│  │        └─ targets: src (11.7k, 100%)
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68
+│  │          return new APIError(status, error, message, headers);
+│  │                 ^
+│  │  
+│  │  APIError: 412 Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.
+│  │      at APIError.generate (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68:16)
+│  │      at OpenAI.makeStatusError (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:158:32)
+│  │      at OpenAI.makeRequest (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:301:30)
+│  │      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+│  │      at async BrainAtom.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-brains-fireworksai@0.1.3_rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensor_8570e921314347f094d9e4f8dc2954da/node_modules/rhachet-brains-fireworksai/dist/domain.operations/atom/genBrainAtom.js:124:30)
+│  │      at async Object.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/brain/asBrainAtomWithContextBound.js:20:24)
+│  │      at async Object.operation (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:546:32)
+│  │      at async withSpinner (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:116:28)
+│  │      at async stepReview (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:544:26)
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:177:9) {
+│  │    status: 412,
+│  │    headers: Headers {},
+│  │    requestID: 'chatcmpl-cd13b2917e8d452eb81c9083669313a1',
+│  │    error: {
+│  │      message: 'Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.',
+│  │      param: null,
+│  │      code: 'PRECONDITION_FAILED',
+│  │      type: 'error'
+│  │    },
+│  │    code: 'PRECONDITION_FAILED',
+│  │    param: null,
+│  │    type: 'error'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r8._.given.by_peer.behavior-intent-coverage.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r8._.given.by_peer.behavior-intent-coverage.md
@@ -1,0 +1,73 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 17
+│  │     │  └─ targets: 2
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 25,541
+│  │     │  └─ context: 2.6%
+│  │     └─ cost
+│  │        └─ estimate: $0.004290860
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T14-22-19-521Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T14-22-19-521Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T14-22-19-521Z/tokens.expected.md
+│  │        ├─ rules: .agent (393, 100%)
+│  │        └─ targets: src (11.7k, 100%)
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68
+│  │          return new APIError(status, error, message, headers);
+│  │                 ^
+│  │  
+│  │  APIError: 412 Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.
+│  │      at APIError.generate (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68:16)
+│  │      at OpenAI.makeStatusError (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:158:32)
+│  │      at OpenAI.makeRequest (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:301:30)
+│  │      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+│  │      at async BrainAtom.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-brains-fireworksai@0.1.3_rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensor_8570e921314347f094d9e4f8dc2954da/node_modules/rhachet-brains-fireworksai/dist/domain.operations/atom/genBrainAtom.js:124:30)
+│  │      at async Object.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/brain/asBrainAtomWithContextBound.js:20:24)
+│  │      at async Object.operation (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:546:32)
+│  │      at async withSpinner (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:116:28)
+│  │      at async stepReview (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:544:26)
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:177:9) {
+│  │    status: 412,
+│  │    headers: Headers {},
+│  │    requestID: 'chatcmpl-bfb1e25e13214d9a9f5d6fd7752f5864',
+│  │    error: {
+│  │      message: 'Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.',
+│  │      param: null,
+│  │      code: 'PRECONDITION_FAILED',
+│  │      type: 'error'
+│  │    },
+│  │    code: 'PRECONDITION_FAILED',
+│  │    param: null,
+│  │    type: 'error'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r9._.given.by_peer.ergo-friction-hazards.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i2.ce6d43b8a997b97bbc.r9._.given.by_peer.ergo-friction-hazards.md
@@ -1,0 +1,73 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 13
+│  │     │  └─ targets: 2
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 19,482
+│  │     │  └─ context: 1.9%
+│  │     └─ cost
+│  │        └─ estimate: $0.003272920
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T14-22-20-779Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T14-22-20-779Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T14-22-20-779Z/tokens.expected.md
+│  │        ├─ rules: .agent (601, 100%)
+│  │        └─ targets: src (11.7k, 100%)
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68
+│  │          return new APIError(status, error, message, headers);
+│  │                 ^
+│  │  
+│  │  APIError: 412 Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.
+│  │      at APIError.generate (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/core/error.js:68:16)
+│  │      at OpenAI.makeStatusError (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:158:32)
+│  │      at OpenAI.makeRequest (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/openai@5.8.2_zod@4.3.4/node_modules/openai/client.js:301:30)
+│  │      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+│  │      at async BrainAtom.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-brains-fireworksai@0.1.3_rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensor_8570e921314347f094d9e4f8dc2954da/node_modules/rhachet-brains-fireworksai/dist/domain.operations/atom/genBrainAtom.js:124:30)
+│  │      at async Object.ask (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet@1.42.2_@huggingface+transformers@3.8.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__@types+node@22.15.21_zod@4.3.4/node_modules/rhachet/dist/domain.operations/brain/asBrainAtomWithContextBound.js:20:24)
+│  │      at async Object.operation (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:546:32)
+│  │      at async withSpinner (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:116:28)
+│  │      at async stepReview (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/domain.operations/review/stepReview.js:544:26)
+│  │      at async Module.review (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/node_modules/.pnpm/rhachet-roles-bhrain@0.29.10_@types+node@22.15.21_rhachet-brains-fireworksai@0.1.3_rhac_14990ddf2b032a31d3d371107627411f/node_modules/rhachet-roles-bhrain/dist/contract/cli/review.js:177:9) {
+│  │    status: 412,
+│  │    headers: Headers {},
+│  │    requestID: 'chatcmpl-f3bba03ba4a9487fb95648c051f10195',
+│  │    error: {
+│  │      message: 'Account vladatahbode is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.',
+│  │      param: null,
+│  │      code: 'PRECONDITION_FAILED',
+│  │      type: 'error'
+│  │    },
+│  │    code: 'PRECONDITION_FAILED',
+│  │    param: null,
+│  │    type: 'error'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r1._.given.by_peer.repo-rules.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r1._.given.by_peer.repo-rules.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r2._.given.by_peer.mech-failhides.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r2._.given.by_peer.mech-failhides.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r3._.given.by_peer.mech-decode-friction.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r3._.given.by_peer.mech-decode-friction.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r4._.given.by_peer.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r4._.given.by_peer.arch-opport-decomposition.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r5._.given.by_peer.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r5._.given.by_peer.arch-smell-scopeleaks.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r6._.given.by_peer.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r6._.given.by_peer.arch-hazards-maintenance.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r7._.given.by_peer.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r7._.given.by_peer.arch-hazards-behavior.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r8._.given.by_peer.behavior-intent-coverage.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r8._.given.by_peer.behavior-intent-coverage.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r9._.given.by_peer.ergo-friction-hazards.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i3.486769294f9ec2d981.r9._.given.by_peer.ergo-friction-hazards.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r1._.given.by_peer.repo-rules.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r1._.given.by_peer.repo-rules.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 4
+│  │     │  └─ targets: 4
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 55,750
+│  │     │  └─ context: 5.6%
+│  │     └─ cost
+│  │        └─ estimate: $0.009366000
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T22-37-24-368Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T22-37-24-368Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T22-37-24-368Z/tokens.expected.md
+│  │        ├─ rules: .agent (2.0k, 100%)
+│  │        └─ targets: src (52.9k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 57,098
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 1,004
+│  │     │  └─ total: 58,102
+│  │     ├─ cost
+│  │     │  └─ total: $0.008274840
+│  │     └─ time
+│  │        └─ total: 27630ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T22-37-24-368Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r1._.given.by_peer.repo-rules.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r1._.given.by_peer.repo-rules.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r1._.given.by_peer.repo-rules.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T22-37-24-368Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r1._.given.by_peer.repo-rules.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r2._.given.by_peer.mech-failhides.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r2._.given.by_peer.mech-failhides.md
@@ -1,0 +1,54 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 11
+│  │     │  └─ targets: 4
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 56,564
+│  │     │  └─ context: 5.7%
+│  │     └─ cost
+│  │        └─ estimate: $0.009502640
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T22-37-55-282Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T22-37-55-282Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T22-37-55-282Z/tokens.expected.md
+│  │        ├─ rules: .agent (2.6k, 100%)
+│  │        └─ targets: src (52.9k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 57,883
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 3,335
+│  │     │  └─ total: 61,218
+│  │     ├─ cost
+│  │     │  └─ total: $0.009037420
+│  │     └─ time
+│  │        └─ total: 45225ms
+│  │  
+│  │  🦉 needs your talons
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T22-37-55-282Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r2._.given.by_peer.mech-failhides.report.md
+│  │     └─ summary
+│  │        ├─ 1 blocker 🔴
+│  │        └─ 0 nitpicks
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r2._.given.by_peer.mech-failhides.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r2._.given.by_peer.mech-failhides.report.md
@@ -1,0 +1,35 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-37-55-282Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r2._.given.by_peer.mech-failhides.report.md
+   └─ summary
+      ├─ 1 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: silent pass-through of side-effect command (relock) without verification
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/pitofsuccess.errors/rule.forbid.failhide.md
+
+**locations**:
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts (case12)
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts (case15)
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts (case16)
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts (case20)
+
+The tests call `spawnSync('npx', ['rhachet', 'keyrack', 'relock', '--owner', 'ehmpath'], ...)` as a setup step but never check the result or exit code. If this command fails (e.g., rhachet not available, network issue), the test may silently pass with incorrect state, leading to false confidence. According to rule.forbid.failhide (tests), every code path must be verified; silent pass-through is forbidden.
+
+Fix: wrap the command in a guard that fails fast on error, e.g., check `result.status` and throw `ConstraintError` or `MalfunctionError` with context.
+
+**snippet**:
+```ts
+// relock ehmpath to clear daemon cache
+spawnSync(
+  'npx',
+  ['rhachet', 'keyrack', 'relock', '--owner', 'ehmpath'],
+  {
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  },
+);
+// result is never checked
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r3._.given.by_peer.mech-decode-friction.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r3._.given.by_peer.mech-decode-friction.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 1
+│  │     │  └─ targets: 4
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 54,971
+│  │     │  └─ context: 5.5%
+│  │     └─ cost
+│  │        └─ estimate: $0.009235100
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T22-38-43-424Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T22-38-43-424Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T22-38-43-424Z/tokens.expected.md
+│  │        ├─ rules: .agent (388, 100%)
+│  │        └─ targets: src (52.9k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 56,163
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 334
+│  │     │  └─ total: 56,497
+│  │     ├─ cost
+│  │     │  └─ total: $0.007956340
+│  │     └─ time
+│  │        └─ total: 15976ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T22-38-43-424Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r3._.given.by_peer.mech-decode-friction.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r3._.given.by_peer.mech-decode-friction.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r3._.given.by_peer.mech-decode-friction.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T22-38-43-424Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r3._.given.by_peer.mech-decode-friction.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r4._.given.by_peer.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r4._.given.by_peer.arch-opport-decomposition.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 28
+│  │     │  └─ targets: 4
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 69,880
+│  │     │  └─ context: 7.0%
+│  │     └─ cost
+│  │        └─ estimate: $0.011739840
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T22-39-02-702Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T22-39-02-702Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T22-39-02-702Z/tokens.expected.md
+│  │        ├─ rules: .agent (554, 100%)
+│  │        └─ targets: src (52.9k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 70,589
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 2,775
+│  │     │  └─ total: 73,364
+│  │     ├─ cost
+│  │     │  └─ total: $0.010659460
+│  │     └─ time
+│  │        └─ total: 35905ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T22-39-02-702Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r4._.given.by_peer.arch-opport-decomposition.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r4._.given.by_peer.arch-opport-decomposition.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r4._.given.by_peer.arch-opport-decomposition.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T22-39-02-702Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r4._.given.by_peer.arch-opport-decomposition.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r5._.given.by_peer.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r5._.given.by_peer.arch-smell-scopeleaks.md
@@ -1,0 +1,56 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 28
+│  │     │  └─ targets: 4
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 69,776
+│  │     │  └─ context: 7.0%
+│  │     └─ cost
+│  │        └─ estimate: $0.011722480
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T22-39-40-411Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T22-39-40-411Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T22-39-40-411Z/tokens.expected.md
+│  │        ├─ rules: .agent (454, 100%)
+│  │        └─ targets: src (52.9k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 70,468
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 10,713
+│  │     │  ├─ output: 630
+│  │     │  └─ total: 81,811
+│  │     ├─ cost
+│  │     │  └─ total: $0.010041920
+│  │     └─ time
+│  │        └─ total: 23920ms
+│  │  
+│  │  🦉 not even a vole
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T22-39-40-411Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r5._.given.by_peer.arch-smell-scopeleaks.report.md
+│  │     └─ summary
+│  │        ├─ 0 blockers
+│  │        ├─ 0 nitpicks
+│  │        └─ all good 👍
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r5._.given.by_peer.arch-smell-scopeleaks.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r5._.given.by_peer.arch-smell-scopeleaks.report.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T22-39-40-411Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r5._.given.by_peer.arch-smell-scopeleaks.report.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r6._.given.by_peer.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r6._.given.by_peer.arch-hazards-maintenance.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 24
+│  │     │  └─ targets: 4
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 61,575
+│  │     │  └─ context: 6.2%
+│  │     └─ cost
+│  │        └─ estimate: $0.010344740
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T22-40-06-575Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T22-40-06-575Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T22-40-06-575Z/tokens.expected.md
+│  │        ├─ rules: .agent (506, 100%)
+│  │        └─ targets: src (52.9k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 62,832
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 5,538
+│  │     │  └─ total: 68,370
+│  │     ├─ cost
+│  │     │  └─ total: $0.010347120
+│  │     └─ time
+│  │        └─ total: 62968ms
+│  │  
+│  │  🦉 needs your talons
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T22-40-06-575Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r6._.given.by_peer.arch-hazards-maintenance.report.md
+│  │     └─ summary
+│  │        ├─ 1 blocker 🔴
+│  │        └─ 0 nitpicks
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r6._.given.by_peer.arch-hazards-maintenance.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r6._.given.by_peer.arch-hazards-maintenance.report.md
@@ -1,0 +1,39 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-40-06-575Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r6._.given.by_peer.arch-hazards-maintenance.report.md
+   └─ summary
+      ├─ 1 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Missing .what/.why headers for named procedures
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/rule.require.what-why-headers.md.min
+
+**locations**:
+- src/domain.roles/mechanic/skills/git.commit/git.commit.uses.integration.test.ts:15
+- src/domain.roles/mechanic/skills/git.commit/git.commit.uses.integration.test.ts:66
+- src/domain.roles/mechanic/skills/git.commit/git.commit.uses.integration.test.ts:90
+- src/domain.roles/mechanic/skills/git.commit/git.commit.uses.integration.test.ts:??
+- src/domain.roles/mechanic/skills/git.commit/git.commit.uses.integration.test.ts:??
+- src/domain.roles/mechanic/skills/git.commit/git.commit.uses.integration.test.ts:??
+
+Several helper functions in git.commit.uses.integration.test.ts lack the required .what/.why JSDoc comments. The rule requires every named procedure to have a header summarizing intent and purpose. This includes:
+- `runInTempGitRepo` (top-level)
+- `runWithGlobalStorage` (top-level)
+- `runWithOrgStorage` (top-level)
+- `runWithoutTtyBypass` (inside case20)
+- `runGlobalWithoutTtyBypass` (inside case21)
+- `runOrgWithoutTtyBypass` (inside case30)
+
+Add .what and .why comments before each function definition to document the purpose and improve maintainability.
+
+**snippet**:
+```ts
+  const runInTempGitRepo = (args: {
+    args: string[];
+    meterState?: { uses: number | string; push: string; stage?: string };
+  }): { stdout: string; stderr: string; exitCode: number; tempDir: string } => {
+    // ... function body ...
+  };
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r7._.given.by_peer.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r7._.given.by_peer.arch-hazards-behavior.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 20
+│  │     │  └─ targets: 4
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 62,323
+│  │     │  └─ context: 6.2%
+│  │     └─ cost
+│  │        └─ estimate: $0.010470180
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T22-41-11-821Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T22-41-11-821Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T22-41-11-821Z/tokens.expected.md
+│  │        ├─ rules: .agent (985, 100%)
+│  │        └─ targets: src (53.1k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 63,306
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 4,828
+│  │     │  └─ total: 68,134
+│  │     ├─ cost
+│  │     │  └─ total: $0.010214680
+│  │     └─ time
+│  │        └─ total: 57089ms
+│  │  
+│  │  🦉 needs your talons
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T22-41-11-821Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r7._.given.by_peer.arch-hazards-behavior.report.md
+│  │     └─ summary
+│  │        ├─ 1 blocker 🔴
+│  │        └─ 0 nitpicks
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r7._.given.by_peer.arch-hazards-behavior.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r7._.given.by_peer.arch-hazards-behavior.report.md
@@ -1,0 +1,39 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-41-11-821Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r7._.given.by_peer.arch-hazards-behavior.report.md
+   └─ summary
+      ├─ 1 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Hidden side effect and non-determinism: keyrack relock in integration tests
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md
+
+**locations**:
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts (case12: 'keyrack not configured' test)
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts (case15: 'real user locked' test)
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts (case16: 'keyrack key not declared' test)
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts (case20: 'both keyrack sources locked' test)
+
+The integration tests in git.commit.push.integration.test.ts perform a keyrack relock by running 'npx rhachet keyrack relock --owner ehmpath' as part of test setup. This is a hidden side effect that modifies external daemon cache state, depends on the availability of the keyrack daemon, and introduces non-determinism and order-dependence. The test throws MalfunctionError if relock fails, making the test fragile and environment-dependent. This violates the forbid-behavior-hazards rule under hidden side effects (writes to external system not obvious from signature) and non-determinism (depends on external state).
+The relock calls appear in case12, case15, case16, and case20. Each uses the same pattern. The test should mock the keyrack interaction or avoid relying on external daemon state.
+
+**snippet**:
+```ts
+// relock ehmpath to clear daemon cache
+const relockResult = spawnSync(
+  'npx',
+  ['rhachet', 'keyrack', 'relock', '--owner', 'ehmpath'],
+  {
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  },
+);
+if (relockResult.status !== 0) {
+  throw new MalfunctionError('keyrack relock failed', {
+    status: relockResult.status,
+    stderr: relockResult.stderr,
+  });
+}
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r8._.given.by_peer.behavior-intent-coverage.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r8._.given.by_peer.behavior-intent-coverage.md
@@ -1,0 +1,55 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │  
+│  │  🦉 let's review
+│  │     ├─ brain: fireworks/deepseek/v4-flash
+│  │     ├─ focus: push
+│  │     └─ scope
+│  │        ├─ diffs: since-main
+│  │        ├─ paths: **/*.ts
+│  │        └─ join: intersect
+│  │  
+│  │  🔭 metrics.expected
+│  │     ├─ files
+│  │     │  ├─ rules: 1
+│  │     │  ├─ refs: 17
+│  │     │  └─ targets: 4
+│  │     ├─ tokens
+│  │     │  ├─ estimate: 67,044
+│  │     │  └─ context: 6.7%
+│  │     └─ cost
+│  │        └─ estimate: $0.011263280
+│  │  
+│  │  🪵 logs
+│  │     ├─ scope: .log/bhrain/review/2026-06-23T22-42-14-700Z/input.scope.json
+│  │     ├─ metrics: .log/bhrain/review/2026-06-23T22-42-14-700Z/metrics.expected.json
+│  │     └─ tokens: .log/bhrain/review/2026-06-23T22-42-14-700Z/tokens.expected.md
+│  │        ├─ rules: .agent (393, 100%)
+│  │        └─ targets: src (53.1k, 100%)
+│  │  
+│  │  ✨ metrics.realized
+│  │     ├─ tokens
+│  │     │  ├─ input: 67,303
+│  │     │  ├─ cache.set: 0
+│  │     │  ├─ cache.get: 0
+│  │     │  ├─ output: 3,785
+│  │     │  └─ total: 71,088
+│  │     ├─ cost
+│  │     │  └─ total: $0.010482220
+│  │     └─ time
+│  │        └─ total: 55231ms
+│  │  
+│  │  🦉 needs your talons
+│  │     ├─ logs: .log/bhrain/review/2026-06-23T22-42-14-700Z
+│  │     ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r8._.given.by_peer.behavior-intent-coverage.report.md
+│  │     └─ summary
+│  │        ├─ 3 blockers 🔴
+│  │        └─ 0 nitpicks
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  └─

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r8._.given.by_peer.behavior-intent-coverage.report.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r8._.given.by_peer.behavior-intent-coverage.report.md
@@ -1,0 +1,79 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-42-14-700Z
+   ├─ review: .behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r8._.given.by_peer.behavior-intent-coverage.report.md
+   └─ summary
+      ├─ 3 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Missing snapshot coverage for continuation commit enforcement output
+
+**rule**: rule.require.contract-snapshot-exhaustiveness.md
+
+**locations**:
+- src/domain.roles/mechanic/skills/git.commit/git.commit.set.integration.test.ts:1900
+- src/domain.roles/mechanic/skills/git.commit/git.commit.set.integration.test.ts:1950
+- src/domain.roles/mechanic/skills/git.commit/git.commit.set.integration.test.ts:2000
+
+In git.commit.set.integration.test.ts, many test cases under 'continuation commit enforcement' (case20 t0–t11) do not include snapshot assertions for stdout or stderr. These tests verify important user-facing error messages (e.g., 'bummer dude', 'first commit must be fix(<scope>): or feat(<scope>):') that should be snapped to catch regressions. The rule requires every contract output variant for positive, negative, and edge cases to be snapped. Without snapshots, changes to these messages will not be reviewed and drift can go undetected.
+
+**snippet**:
+```ts
+// Example from case20 t0 (first behavioral fix) – no snapshot
+const result = spawnSync(...);
+expect(result.status).toBe(0);
+expect(result.stdout).toContain('righteous!');
+// Missing: expect(result.stdout).toMatchSnapshot();
+```
+
+---
+
+# blocker.2: No real integration test for external GitHub API (gh cli)
+
+**rule**: rule.require.external-contract-integration-tests.md
+
+**locations**:
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts:144
+- src/domain.roles/mechanic/skills/git.commit/git.commit.set.integration.test.ts:157
+- src/domain.roles/mechanic/skills/git.commit/git.commit.uses.integration.test.ts:45
+
+All target tests mock the gh CLI binary to simulate token validation and PR creation. The vision.md does not declare an explicit exception for mocking the GitHub API, and even when an exception exists, at least one real integration test must call the real service with real credentials. These target files contain no such test. Without a real integration test, mock drift can mask failures in the real GitHub API contract. This is a blocker.
+
+**snippet**:
+```ts
+// Mock gh CLI in git.commit.push.integration.test.ts:144-155
+const fakeBinDir = path.join(tempDir, '.fakebin');
+fs.mkdirSync(fakeBinDir, { recursive: true });
+fs.writeFileSync(
+  path.join(fakeBinDir, 'gh'),
+  `#!/bin/bash
+if [[ "$1" == "api" && "$2" == "/user" ]]; then
+  echo '{"login":"ehm-seaturtle"}'
+  exit 0
+fi
+exit 1`
+);
+```
+
+---
+
+# blocker.3: Missing snapshots for deterministic push test outputs
+
+**rule**: rule.require.contract-snapshot-exhaustiveness.md
+
+**locations**:
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts:540
+- src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts:595
+
+In git.commit.push.integration.test.ts, test cases case10 (meter not decremented) and case11 (pr title fallback) do not include snapshot assertions for stdout. These outputs are deterministic and user-facing (e.g., JSON plan output). The rule requires snapshots for all contract variants. Gaps allow output changes to go unnoticed in PR reviews.
+
+**snippet**:
+```ts
+// case10: meter not decremented – no snapshot
+then('uses remain unchanged', () => {
+  ...
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+  expect(state.uses).toBe(3);
+});
+// Missing: snapshot of plan output
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r9._.given.by_peer.ergo-friction-hazards.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i4.486769294f9ec2d981.r9._.given.by_peer.ergo-friction-hazards.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r1._.given.by_peer.repo-rules.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r1._.given.by_peer.repo-rules.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r2._.given.by_peer.mech-failhides.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r2._.given.by_peer.mech-failhides.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r3._.given.by_peer.mech-decode-friction.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r3._.given.by_peer.mech-decode-friction.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r4._.given.by_peer.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r4._.given.by_peer.arch-opport-decomposition.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r5._.given.by_peer.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r5._.given.by_peer.arch-smell-scopeleaks.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r6._.given.by_peer.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r6._.given.by_peer.arch-hazards-maintenance.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r7._.given.by_peer.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r7._.given.by_peer.arch-hazards-behavior.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r8._.given.by_peer.behavior-intent-coverage.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r8._.given.by_peer.behavior-intent-coverage.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r9._.given.by_peer.ergo-friction-hazards.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.reviews/peer/5.1.execution.phase0_to_phaseN._.review.i5.7af01c224b1662174a.r9._.given.by_peer.ergo-friction-hazards.md
@@ -1,0 +1,29 @@
+├─ stdout
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │
+│  └─
+├─ stderr
+│  ├─
+│  │
+│  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+│  │     └─ 💥 failed with an error
+│  │  
+│  │  node:internal/process/promises:394
+│  │      triggerUncaughtException(err, true /* fromPromise */);
+│  │      ^
+│  │  
+│  │  [Error: EACCES: permission denied, scandir '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'] {
+│  │    errno: -13,
+│  │    code: 'EACCES',
+│  │    syscall: 'scandir',
+│  │    path: '/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-ehmpathy.vlad.git-commit-uses-grain/.temp/genTempDir.symlink/2026-06-23T13-46-35.415Z.mvsafe-test.c583d639/sneaky-dir/snap-private-tmp'
+│  │  }
+│  │  
+│  │  Node.js v22.21.0
+│  │
+│  └─
+└─ passage blocked
+   ├─ blocked by malfunction
+   └─ exit code: 1 💥

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.route/.bind.vlad.git-commit-uses-grain.flag
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.route/.bind.vlad.git-commit-uses-grain.flag
@@ -1,0 +1,2 @@
+branch: vlad/git-commit-uses-grain
+bound_by: route.bind skill

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.route/.gitignore
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_06_22.git-commit-uses-grain/.route/passage.jsonl
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/.route/passage.jsonl
@@ -1,0 +1,33 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"2.1.criteria.blackbox","status":"passed"}
+{"stone":"2.1.criteria.blackbox","status":"passed"}
+{"stone":"2.2.criteria.blackbox.matrix","status":"passed"}
+{"stone":"3.1.1.research.external.product.flagged._","status":"passed"}
+{"stone":"3.1.3.research.internal.product.code.prod._","status":"passed"}
+{"stone":"3.1.3.research.internal.product.code.test._","status":"passed"}
+{"stone":"3.3.1.blueprint.product","status":"blocked","blocker":"review.self","reason":"review.self required: has-research-citations"}
+{"stone":"3.3.1.blueprint.product","status":"blocked","blocker":"review.self","reason":"review.self required: has-research-citations"}
+{"stone":"3.3.1.blueprint.product","status":"blocked","blocker":"review.self","reason":"review.self required: has-consistent-conventions"}
+{"stone":"3.3.1.blueprint.product","status":"blocked","blocker":"review.self","reason":"review.self required: has-behavior-declaration-coverage"}
+{"stone":"3.3.1.blueprint.product","status":"blocked","blocker":"review.self","reason":"review.self required: has-role-standards-adherance"}
+{"stone":"3.3.1.blueprint.product","status":"malfunction"}
+{"stone":"3.3.1.blueprint.product","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (1 > 0); wait for human approval"}
+{"stone":"3.3.1.blueprint.product","status":"blocked"}
+{"stone":"3.3.1.blueprint.product","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (1 > 0); wait for human approval"}
+{"stone":"3.3.1.blueprint.product","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (1 > 0); wait for human approval"}
+{"stone":"3.3.1.blueprint.product","status":"blocked"}
+{"stone":"3.3.1.blueprint.product","status":"approved"}
+{"stone":"3.3.1.blueprint.product","status":"overruled"}
+{"stone":"3.3.1.blueprint.product","status":"passed"}
+{"stone":"4.1.roadmap","status":"passed"}
+{"stone":"5.1.execution.phase0_to_phaseN","status":"blocked"}
+{"stone":"5.1.execution.phase0_to_phaseN","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.phase0_to_phaseN","status":"blocked","blocker":"review.self","reason":"review.self required: behavior-declaration-adherance"}
+{"stone":"5.1.execution.phase0_to_phaseN","status":"malfunction"}
+{"stone":"5.1.execution.phase0_to_phaseN","status":"malfunction"}
+{"stone":"5.1.execution.phase0_to_phaseN","status":"malfunction"}
+{"stone":"5.1.execution.phase0_to_phaseN","status":"malfunction"}
+{"stone":"5.1.execution.phase0_to_phaseN","status":"malfunction"}

--- a/.behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
@@ -1,0 +1,62 @@
+wish =
+
+we need to add org level grains to git.commit.uses
+
+so that we can block and allow uses at the org granularity
+
+---
+
+e.g., 
+
+rhx git.commit.uses block --global
+
+blocks everything, regardless of org
+
+---
+
+rhx git.commit.uses block --org @all
+
+blocks all org level grants. finds any that have been set, and sets them all to blocked
+
+---
+
+rhx git.commit.uses allow --org $org
+
+sets an org level grant
+
+
+---
+
+as usual, global overrules all
+
+---
+
+typically, if someone wants to block all orgs but allow one, they can 
+
+rhx git.commit.uses block --org @all --global
+
+rhx git.commit.uses allow --global
+
+and then
+
+rhx git.commit.uses allow --org $org (e.g., --org ehmpathy)
+
+---
+
+that way, all orgs are blocked
+
+except the explicitly allowlisted orgs
+
+---
+
+and we should maintain the allowlist carefully
+
+becasue we dont want new orgs to come in and be default allowed (dangerous)
+
+so its default block
+
+and allowlist each org one by one 
+
+---
+
+or, allowlist all orgs (flip the dfeault) via `rhx git.commit.uses allow --org @all`

--- a/.behavior/v2026_06_22.git-commit-uses-grain/1.vision.guard
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/1.vision.guard
@@ -1,0 +1,89 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_06_22.git-commit-uses-grain/1.vision.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+
+emit into .behavior/v2026_06_22.git-commit-uses-grain/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_06_22.git-commit-uses-grain/1.vision.yield.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/1.vision.yield.md
@@ -1,0 +1,273 @@
+# vision: org-level blockers for git.commit.uses
+
+## the outcome world
+
+### day-in-the-life
+
+**before**: a human works across multiple orgs (ehmpathy, ahbode, bhrain). today, global blocker is the only macro-scale control:
+- global blocked → all repos blocked
+- global unblocked → no blocker at macro scale
+
+no middle ground. want org-level blockers without global block.
+
+**after**: human sets org-level blockers instead of global:
+```sh
+rhx git.commit.uses block --org @all          # all orgs blocked (default-deny mode)
+rhx git.commit.uses allow --org ehmpathy      # unlock ehmpathy
+```
+
+now:
+- not globally blocked
+- org-level blocked with default-deny
+- ehmpathy: unlocked (local quota still required)
+- unknown orgs: blocked at org level
+
+### before/after contrast
+
+| before | after |
+|--------|-------|
+| global blocker only | org-level blockers |
+| all-or-none control | per-org control |
+| no safe default for unknown orgs | @all sets the default |
+
+**key**: org-level blockers provide granularity without global block. local quota still required to grant access.
+
+### "aha" moment
+
+the aha clicks when:
+- human wants macro control but not global block
+- `block --org @all` blocks all orgs (safe default)
+- `allow --org ehmpathy` unlocks one org
+- result: org-level blocked, not globally blocked
+
+## user experience
+
+### usecases
+
+1. **default-deny mode**: block all orgs, unlock trusted ones
+   ```sh
+   rhx git.commit.uses block --org @all
+   rhx git.commit.uses allow --org ehmpathy
+   ```
+
+2. **default-allow mode**: allow all orgs, block risky ones
+   ```sh
+   rhx git.commit.uses allow --org @all
+   rhx git.commit.uses block --org external-client
+   ```
+
+3. **check current state**: see org blockers
+   ```sh
+   rhx git.commit.uses get --org
+   ```
+
+4. **remove org override**: defer back to @all default
+   ```sh
+   rhx git.commit.uses del --org ahbode
+   ```
+
+**note**: @all = default mode + reset. `block --org @all` resets all orgs to blocked and sets the default.
+
+### contract inputs & outputs
+
+**inputs**:
+- `--org <name>` — org name (e.g., `ehmpathy`, `ahbode`, `@all`)
+- `allow | block | del | get` — command
+
+**outputs** (turtle vibes):
+```
+🐢 shell yeah, back in the water!
+
+🐚 git.commit.uses allow --org ehmpathy
+   └─ ehmpathy: allowed
+```
+
+```
+🐢 lets check the meter...
+
+🐚 git.commit.uses get --org
+   ├─ @all: blocked
+   ├─ ehmpathy: allowed
+   └─ ahbode: allowed
+```
+
+### timelines
+
+1. **initial setup** (once): human configures org defaults
+2. **ongoing**: mechanic hits org check automatically at commit time
+3. **adjustment** (rare): human adds/removes org allowlist entries
+
+## mental model
+
+### how users describe it
+
+> "i set org-level blockers instead of global. @all=blocked, ehmpathy=unlocked."
+
+> "it's not globally blocked — it's org-level blocked with a default."
+
+### analogies
+
+- **firewall rules** — @all resets all + sets default policy, specific orgs override
+- **layered blockers** — global > org > local, each layer can block
+- **factory reset** — @all wipes all org configs and sets the new default
+
+### terms alignment
+
+| user term | our term |
+|-----------|----------|
+| "unlock org" | `allow --org` |
+| "block org" | `block --org` |
+| "reset all + set default" | `block --org @all` or `allow --org @all` |
+| "global kill switch" | `--global` |
+
+## evaluation
+
+### how well does it solve the goals?
+
+**goal**: org-level blockers without global block → **solved**: `--org` flag with @all default
+
+**goal**: default mode + reset → **solved**: `block --org @all` resets all orgs + sets default
+
+**goal**: per-org override → **solved**: `allow --org $org` or `block --org $org` overrides @all
+
+### pros
+
+- org-level control without global block
+- @all sets default mode (block or allow)
+- individual orgs can override the default
+- follows extant `radio.uses` pattern (consistency)
+
+### cons
+
+- requires `.agent/keyrack.yml#org` to be set
+- users must understand @all as default + reset
+- three-tier hierarchy (global > org > local)
+
+### edgecases and pit-of-success
+
+| edgecase | action |
+|----------|--------|
+| keyrack.yml absent | failfast: "keyrack.yml required" |
+| keyrack.yml#org unset | failfast: "keyrack.yml#org required" |
+| `@all` is typo'd as `all` | error: "did you mean @all?" |
+| org blocked but local has quota | org blocker wins, mechanic cannot commit |
+
+## open questions & assumptions
+
+### assumptions
+
+1. **org from keyrack.yml**: assumes `.agent/keyrack.yml#org` is set for org-level checks
+2. **one org per repo**: assumes repos belong to exactly one org
+3. **precedence clear**: global > org > local (broader scope wins). @all sets default + resets all, not a separate tier.
+
+### questions for wisher
+
+none — all questions answered.
+
+### questions answered
+
+2. [answered] **org detection**: read from `.agent/keyrack.yml#org`. if absent, failfast (mechanic role requires keyrack).
+3. [answered] **@all semantics**: @all = default mode + reset. `block --org @all` resets all orgs to blocked AND sets default to blocked. individual org overrides can then unlock specific orgs.
+4. [answered] **precedence**: global > org > local. broader scope wins. wisher confirmed.
+5. [answered] **quota asymmetry**: org-level is coarse (allowed/blocked only), local has quota counts. asymmetry is intentional. wisher confirmed.
+
+### external research needed
+
+none — no external APIs or services referenced
+
+## groundwork
+
+### external research
+
+none — no external dependencies
+
+### internal research
+
+**extant behavior checked**:
+
+1. **git.commit.uses structure** (`src/domain.roles/mechanic/skills/git.commit/git.commit.uses.sh:1-46`)
+   - dispatches to `git.commit.uses.local.sh` or `git.commit.uses.global.sh` based on `--global` flag
+   - pattern to follow: add `--org` dispatch to `git.commit.uses.org.sh`
+
+2. **global handler** (`src/domain.roles/mechanic/skills/git.commit/git.commit.uses.global.sh:1-159`)
+   - stores state at `~/.rhachet/storage/repo=ehmpathy/role=mechanic/.meter/git.commit.uses.jsonc`
+   - uses `{ "blocked": true }` schema
+
+3. **local handler** (`src/domain.roles/mechanic/skills/git.commit/git.commit.uses.local.sh:1-375`)
+   - stores state at `.meter/git.commit.uses.jsonc` in repo
+   - uses `{ "uses": N, "push": "allow"|"block", "stage": "allow"|"block" }` schema
+
+4. **global blocker check** (`src/domain.roles/mechanic/skills/git.commit/git.commit.operations.sh:28-48`)
+   - `check_global_blocker()` function checks global state
+   - pattern to follow: add `check_org_blocker()` for org-level check
+
+5. **radio.uses.org reference** (`rhachet-roles-bhuild:src/domain.roles/dispatcher/skills/radio.uses.org.sh`)
+   - stores at `~/.rhachet/storage/repo=bhuild/role=dispatcher/.meter/radio.uses.org.jsonc`
+   - uses `{ "orgs": { "ehmpathy": "allowed", "@all": "blocked" } }` schema
+   - good pattern to follow
+
+6. **keyrack.yml for org** (`.agent/keyrack.yml`)
+   - has `org: ehmpathy` at line 1
+   - use this for org detection instead of git remote
+
+**vocab to reuse**:
+- `block`, `allow`, `del`, `get` — commands
+- `--org`, `--global` — scope flags
+- `@all` — default org wildcard
+- turtle vibes output utilities from `output.sh`
+
+**stdout patterns to match**:
+```
+🐢 {vibe phrase}
+
+🐚 git.commit.uses {command} --org {org}
+   └─ {org}: {state}
+```
+
+## what is awkward?
+
+### precedence complexity
+
+the three-tier hierarchy (global > org > local) adds mental overhead. users must understand:
+- global blocks all regardless
+- org blocks regardless of local quota (broader scope wins)
+- @all sets the default mode for orgs
+- `allow --org` = unlocks org, does not grant access (local quota still required)
+
+this is logical but requires explanation.
+
+### org detection
+
+org is read from `.agent/keyrack.yml#org`:
+```yaml
+org: ehmpathy
+```
+
+no parse required. if keyrack.yml absent or org unset, failfast (mechanic role requires keyrack).
+
+### @all = default mode + reset
+
+`block --org @all` and `allow --org @all` do two things:
+1. **set default mode** for orgs without explicit config
+2. **reset all orgs** to that mode
+
+so `block --org @all`:
+- resets all individual org configs to blocked
+- sets default to blocked for future orgs
+
+typical workflow:
+```sh
+rhx git.commit.uses block --org @all           # reset all + default-deny
+rhx git.commit.uses allow --org ehmpathy       # unlock ehmpathy specifically
+```
+
+result: all orgs blocked except ehmpathy.
+
+### org vs local asymmetry
+
+org-level is coarse: `allowed`/`blocked` only (blocker or no blocker).
+local-level is fine: quota counts, push permission, stage permission.
+
+this asymmetry is intentional:
+- org = macro-scale blockers
+- local = fine-grained access control per repo

--- a/.behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.stone
@@ -1,0 +1,61 @@
+declare the blackbox criteria required to fulfill
+- this wish .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+- this vision .behavior/v2026_06_22.git-commit-uses-grain/1.vision.md (if declared)
+
+via bdd declarations, per your briefs
+
+emit into .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.yield.md
+
+---
+
+blackbox criteria = experience boundaries (no implementation details)
+
+## episode experience
+
+a sequence of exchanges — the narrative flow
+
+- what workflows do users go through?
+- what do they see, do, and receive at each step?
+- what are the critical paths through the episode?
+- what are the edge cases in the narrative?
+
+## exchange experience
+
+atomic — a single input→output contract
+
+- what inputs does the system accept?
+- what outputs does the system return?
+- what errors does the system surface?
+- what are the boundary conditions?
+
+---
+
+DO NOT include:
+- mechanism details (what contracts/components exist)
+- implementation details (how things are built)
+
+note: blackbox is NOT "why to build" — that's the wish
+      blackbox is "what experience must be delivered" to fulfill the wish
+
+---
+
+## template
+
+```
+# usecase.1 = ...
+given()
+  when()
+    then()
+      sothat()
+    then()
+    then()
+      sothat()
+  when()
+    then()
+
+given()
+  ...
+
+# usecase.2 = ...
+...
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.yield.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.yield.md
@@ -1,0 +1,194 @@
+# blackbox criteria: git.commit.uses --org
+
+## usecase.1 = default-deny mode
+
+human blocks all orgs, then unlocks trusted ones.
+
+```
+given('no org config')
+  when('human runs block --org @all')
+    then('all orgs are blocked')
+      sothat('unknown orgs cannot commit')
+    then('@all: blocked in output')
+      sothat('human sees the default mode')
+
+given('@all: blocked')
+  when('human runs allow --org ehmpathy')
+    then('ehmpathy is unlocked')
+      sothat('ehmpathy repos can commit (with local quota)')
+    then('other orgs remain blocked')
+      sothat('unknown orgs still cannot commit')
+
+given('@all: blocked, ehmpathy: allowed')
+  when('mechanic commits in ehmpathy repo with local quota')
+    then('commit succeeds')
+      sothat('trusted orgs work as expected')
+
+given('@all: blocked, ahbode: unset')
+  when('mechanic commits in ahbode repo with local quota')
+    then('commit fails: org blocked')
+      sothat('unknown orgs are protected')
+```
+
+## usecase.2 = default-allow mode
+
+human allows all orgs, then blocks risky ones.
+
+```
+given('no org config')
+  when('human runs allow --org @all')
+    then('all orgs are allowed')
+      sothat('all repos can commit (with local quota)')
+    then('@all: allowed in output')
+      sothat('human sees the default mode')
+
+given('@all: allowed')
+  when('human runs block --org external-client')
+    then('external-client is blocked')
+      sothat('risky orgs cannot commit')
+    then('other orgs remain allowed')
+      sothat('trusted orgs still work')
+
+given('@all: allowed, external-client: blocked')
+  when('mechanic commits in external-client repo with local quota')
+    then('commit fails: org blocked')
+      sothat('risky orgs are protected')
+```
+
+## usecase.3 = @all resets all orgs
+
+@all = default mode + reset.
+
+```
+given('ehmpathy: allowed, ahbode: allowed')
+  when('human runs block --org @all')
+    then('ehmpathy: blocked')
+      sothat('all orgs are reset')
+    then('ahbode: blocked')
+      sothat('all orgs are reset')
+    then('@all: blocked')
+      sothat('default is set')
+
+given('ehmpathy: blocked, ahbode: blocked')
+  when('human runs allow --org @all')
+    then('ehmpathy: allowed')
+      sothat('all orgs are reset')
+    then('ahbode: allowed')
+      sothat('all orgs are reset')
+    then('@all: allowed')
+      sothat('default is set')
+```
+
+## usecase.4 = check org state
+
+human inspects org blockers.
+
+```
+given('@all: blocked, ehmpathy: allowed')
+  when('human runs get --org')
+    then('output shows @all: blocked')
+    then('output shows ehmpathy: allowed')
+      sothat('human sees all org configs')
+
+given('@all: blocked, ehmpathy: allowed')
+  when('human runs get --org ehmpathy')
+    then('output shows ehmpathy: allowed')
+      sothat('human sees specific org config')
+
+given('@all: blocked, ahbode: unset')
+  when('human runs get --org ahbode')
+    then('output shows ahbode: blocked (from @all)')
+      sothat('human sees effective state')
+```
+
+## usecase.5 = remove org override
+
+human removes org override to defer to @all.
+
+```
+given('@all: blocked, ehmpathy: allowed')
+  when('human runs del --org ehmpathy')
+    then('ehmpathy config is removed')
+    then('ehmpathy inherits from @all: blocked')
+      sothat('org defers to default')
+
+given('@all: allowed, external-client: blocked')
+  when('human runs del --org external-client')
+    then('external-client config is removed')
+    then('external-client inherits from @all: allowed')
+      sothat('org defers to default')
+```
+
+## usecase.6 = precedence: global > org > local
+
+broader scope wins.
+
+```
+given('global: blocked')
+  when('org: allowed, local quota set')
+    then('commit fails: global blocked')
+      sothat('global kill switch works')
+
+given('global: unset, org: blocked')
+  when('local quota set')
+    then('commit fails: org blocked')
+      sothat('org blocker wins over local')
+
+given('global: unset, org: allowed')
+  when('local quota unset')
+    then('commit fails: no local quota')
+      sothat('local quota still required')
+
+given('global: unset, org: allowed, local quota set')
+  when('mechanic commits')
+    then('commit succeeds')
+      sothat('all layers must allow')
+```
+
+## usecase.7 = org detection from keyrack.yml
+
+org is read from .agent/keyrack.yml#org.
+
+```
+given('keyrack.yml with org: ehmpathy')
+  when('mechanic commits')
+    then('org check uses ehmpathy')
+      sothat('org is read from keyrack')
+
+given('keyrack.yml absent')
+  when('mechanic commits')
+    then('failfast: keyrack.yml required')
+      sothat('mechanic role requires keyrack')
+
+given('keyrack.yml with org: unset')
+  when('mechanic commits')
+    then('failfast: keyrack.yml#org required')
+      sothat('org must be declared')
+```
+
+## usecase.8 = human-only mutations
+
+only humans can mutate org config.
+
+```
+given('mechanic (non-tty)')
+  when('runs allow --org ehmpathy')
+    then('fails: only humans can run this')
+      sothat('mechanics cannot change their own permissions')
+
+given('human (tty)')
+  when('runs allow --org ehmpathy')
+    then('succeeds')
+      sothat('humans control permissions')
+```
+
+## usecase.9 = typo protection
+
+pit-of-success for common errors.
+
+```
+given('human runs block --org all')
+  when('all without @ prefix')
+    then('error: did you mean @all?')
+      sothat('typos are caught')
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/2.2.criteria.blackbox.matrix.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/2.2.criteria.blackbox.matrix.stone
@@ -1,0 +1,47 @@
+distill the blackbox criteria in .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.md into a coverage matrix
+
+emit into .behavior/v2026_06_22.git-commit-uses-grain/2.2.criteria.blackbox.matrix.yield.md
+
+---
+
+create a matrix table for each related set of usecases
+
+## process
+
+1. **extract dimensions** — identify the independent variables that vary across usecases
+2. **enumerate combinations** — list all dimension value combinations
+3. **map outcomes** — for each combination, record the expected outcome from blackbox criteria
+4. **flag gaps** — if any combination lacks a specified outcome, call it out
+5. **flag decomposition opportunities** — if too many dimensions, suggest narrower behavioral boundaries
+
+## structure
+
+| ind: var 1 | ind: var 2 | ... | dep: var 1 | dep: var 2 | ... |
+|-------------------|-------------------|-----|-----------------|-----------------|-----|
+| condition A       | condition X       | ... | outcome 1       | outcome 2       | ... |
+| condition A       | condition Y       | ... | outcome 1       | outcome 2       | ... |
+| condition B       | condition X       | ... | outcome 1       | outcome 2       | ... |
+
+explicitly label the ind(ependent) vs dep(endent) varialbes in the table header, as well
+
+## terminology
+
+- independent variables: the inputs/conditions that vary between subcases
+- dependent variables: the expected outcomes for each combination (can be multiple per row)
+
+## why
+
+- visualize all combinations at a glance
+- spot gaps via symmetric analysis — if a row is absent, ask why
+- verify the blackbox criteria covers all meaningful permutations
+
+## decomposition signal
+
+if there are too many independent variables (matrix explodes) — this signals the usecase is too broad
+
+callout opportunities to decompose into smaller behavioral boundaries when:
+- the matrix has 4+ independent dimensions
+- combinations exceed what's reasonable to enumerate
+- unrelated concerns are bundled together
+
+a narrower scope = a clearer matrix = a more maintainable and recomposable system

--- a/.behavior/v2026_06_22.git-commit-uses-grain/2.2.criteria.blackbox.matrix.yield.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/2.2.criteria.blackbox.matrix.yield.md
@@ -1,0 +1,99 @@
+# blackbox coverage matrix: git.commit.uses --org
+
+## matrix.1: commit permission (precedence)
+
+the core question: can mechanic commit?
+
+| ind: global | ind: org | ind: local quota | dep: commit result |
+|-------------|----------|------------------|-------------------|
+| blocked | * | * | fail: global blocked |
+| unset | blocked | set | fail: org blocked |
+| unset | blocked | unset | fail: org blocked |
+| unset | allowed | unset | fail: no local quota |
+| unset | allowed | set | success |
+| unset | unset | * | fail: org unset (failfast) |
+
+**note**: global > org > local. each layer must allow (or be unset for global).
+
+## matrix.2: org effective state
+
+how does org state derive?
+
+| ind: @all | ind: specific org | dep: effective state |
+|-----------|-------------------|---------------------|
+| blocked | unset | blocked |
+| blocked | blocked | blocked |
+| blocked | allowed | allowed |
+| allowed | unset | allowed |
+| allowed | blocked | blocked |
+| allowed | allowed | allowed |
+| unset | unset | unset (failfast) |
+| unset | blocked | blocked |
+| unset | allowed | allowed |
+
+**note**: specific org overrides @all. if both unset, failfast.
+
+## matrix.3: @all reset behavior
+
+what happens when @all is set?
+
+| ind: prior state | ind: command | dep: @all | dep: org.ehmpathy | dep: org.ahbode |
+|------------------|--------------|-----------|-------------------|-----------------|
+| ehmpathy: allowed, ahbode: allowed | block --org @all | blocked | blocked | blocked |
+| ehmpathy: blocked, ahbode: blocked | allow --org @all | allowed | allowed | allowed |
+| ehmpathy: allowed, ahbode: unset | block --org @all | blocked | blocked | blocked |
+| @all: blocked, ehmpathy: allowed | block --org @all | blocked | blocked | n/a |
+
+**note**: @all = reset all + set default. all individual configs are reset to the new @all value.
+
+## matrix.4: mutation permissions
+
+who can run which commands?
+
+| ind: caller | ind: command | dep: result |
+|-------------|--------------|-------------|
+| human (tty) | allow --org | success |
+| human (tty) | block --org | success |
+| human (tty) | del --org | success |
+| human (tty) | get --org | success |
+| mechanic (non-tty) | allow --org | fail: human only |
+| mechanic (non-tty) | block --org | fail: human only |
+| mechanic (non-tty) | del --org | fail: human only |
+| mechanic (non-tty) | get --org | success |
+
+**note**: mutations require human. get is read-only, allowed for mechanics.
+
+## matrix.5: keyrack.yml org detection
+
+how is org determined?
+
+| ind: keyrack.yml | ind: keyrack.yml#org | dep: org check |
+|------------------|---------------------|----------------|
+| present | set (e.g., ehmpathy) | uses ehmpathy |
+| present | unset | failfast: #org required |
+| absent | n/a | failfast: keyrack.yml required |
+
+**note**: mechanic role requires keyrack.yml with org set. no fallback.
+
+## matrix.6: typo protection
+
+pit-of-success for @all.
+
+| ind: input | dep: result |
+|------------|-------------|
+| --org @all | success |
+| --org all | error: did you mean @all? |
+| --org ALL | error: did you mean @all? |
+
+## gaps identified
+
+none. all meaningful combinations are covered by the blackbox criteria.
+
+## decomposition opportunities
+
+the matrices are manageable (2-3 independent variables each). no decomposition needed.
+
+the commit permission matrix (matrix.1) could theoretically explode if we added more factors, but:
+- global/org/local is a clean 3-layer hierarchy
+- each layer has a simple allow/block/unset state
+- the precedence rule (global > org > local) collapses complexity

--- a/.behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.flagged._.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.flagged._.stone
@@ -1,0 +1,49 @@
+research whatever the vision flagged for research
+- read the vision at .behavior/v2026_06_22.git-commit-uses-grain/1.vision.md
+- identify topics, questions, or areas explicitly flagged for research
+- if the vision mentions "research X" or "look into Y" or "find out about Z", research those
+
+---
+
+use web search to discover and research
+- cite every claim
+- number each citation
+- clone exact quotes from each citation
+
+for each research topic, cite atleast 7 sources, with links and quotes
+
+source diversity
+- require mix of source types: official docs, academic papers, practitioner blogs, conference talks
+- prevents echo chamber from only one type
+
+for each citation include
+- publication date (to assess recency)
+- credibility tag: [official] [academic] [practitioner] [tutorial] [blog] [video] [book]
+
+conflict detection
+- explicitly note when sources disagree
+- "sources [3] and [7] conflict on X — [3] says A, [7] says B"
+
+convergence signal
+- note when multiple independent sources agree
+- stronger confidence when 3+ sources say the same
+
+---
+
+explicitly label each claim found from research as either
+- a [FACT] = an indisputable, immutable truth
+or
+- a [SUMP] = an assumption, that someone has made, either explicitly or implicitly
+or
+- a [KHUE] = an open question, that we too should consider
+or
+- a [OPIN] = an opinion, a subjective declaration, that we should consider
+
+---
+
+if the vision does not flag topics for research, emit:
+"no [research] flagged topics in vision"
+
+---
+
+emit into .behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.flagged._.yield.md

--- a/.behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.flagged._.yield.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.flagged._.yield.md
@@ -1,0 +1,9 @@
+# external research: flagged topics
+
+no [research] flagged topics in vision.
+
+the vision explicitly states:
+> ### external research needed
+> none — no external APIs or services referenced
+
+this behavior replicates the extant `radio.uses.org` pattern from `rhachet-roles-bhuild` — no external dependencies.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.prod._.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.prod._.stone
@@ -1,0 +1,31 @@
+research the prod codepath patterns available in order to fulfill
+- this wish .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+- this vision .behavior/v2026_06_22.git-commit-uses-grain/1.vision.md (if declared)
+- this criteria .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.md (if declared)
+- this criteria .behavior/v2026_06_22.git-commit-uses-grain/2.3.criteria.blueprint.md (if declared)
+
+specifically
+- what are the current key patterns in this repo, that are relevant?
+- how do they relate to the wish?
+- which ones will we reuse? which ones will we extend? which ones will we replace?
+  - mark with
+    - [REUSE]
+    - [EXTEND]
+    - [REPLACE]
+
+---
+
+focus exclusively on the production codepaths. ignore test codepaths
+
+note, this includes any infra that production codepaths depend on
+
+---
+
+enumerate each pattern
+- cite every claim
+- number each citation
+- clone exact quotes from each citation
+
+---
+
+emit into .behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.prod._.yield.md

--- a/.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.prod._.yield.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.prod._.yield.md
@@ -1,0 +1,189 @@
+# internal research: production codepaths
+
+## pattern.1: dispatcher pattern
+
+[REUSE] git.commit.uses.sh dispatches to handlers based on flags.
+
+```bash
+# git.commit.uses.sh:29-46
+# check for --global flag
+GLOBAL_MODE=false
+ARGS=()
+
+for arg in "$@"; do
+  if [[ "$arg" == "--global" ]]; then
+    GLOBAL_MODE=true
+  else
+    ARGS+=("$arg")
+  fi
+done
+
+# dispatch to appropriate handler
+if [[ "$GLOBAL_MODE" == "true" ]]; then
+  exec "$SCRIPT_DIR/git.commit.uses.global.sh" "${ARGS[@]}"
+else
+  exec "$SCRIPT_DIR/git.commit.uses.local.sh" "${ARGS[@]}"
+fi
+```
+
+**how to extend**: add `--org` flag detection and dispatch to `git.commit.uses.org.sh`.
+
+## pattern.2: global handler structure
+
+[REUSE] global handler uses block/allow/get commands with TTY guard.
+
+```bash
+# git.commit.uses.global.sh:96-105
+case "$COMMAND" in
+  block|allow)
+    if [[ ! -t 0 && "${__I_AM_HUMAN:-}" != "true" ]]; then
+      print_turtle_header "bummer dude..."
+      print_tree_start "git.commit.uses $COMMAND --global"
+      print_tree_error "only humans can run this command"
+      exit 2
+    fi
+    ;;
+esac
+```
+
+**how to extend**: replicate this TTY guard pattern for org mutations.
+
+## pattern.3: global storage path
+
+[REUSE] global state stored at `~/.rhachet/storage/repo=$ROLE_REPO/role=$ROLE_SLUG/.meter/`.
+
+```bash
+# git.commit.uses.global.sh:29-32
+ROLE_REPO="ehmpathy"
+ROLE_SLUG="mechanic"
+GLOBAL_METER_DIR="$HOME/.rhachet/storage/repo=$ROLE_REPO/role=$ROLE_SLUG/.meter"
+GLOBAL_METER_FILE="$GLOBAL_METER_DIR/git.commit.uses.jsonc"
+```
+
+**how to extend**: org state at same location: `git.commit.uses.org.jsonc`.
+
+## pattern.4: global blocker check
+
+[EXTEND] check_global_blocker() in operations.sh.
+
+```bash
+# git.commit.operations.sh:28-48
+check_global_blocker() {
+  GLOBAL_BLOCK_REASON=""
+
+  if [[ ! -f "$GLOBAL_METER_FILE" ]]; then
+    return 0  # not blocked
+  fi
+
+  # check if file is valid json
+  local blocked_val
+  if ! blocked_val=$(jq -r '.blocked // false' "$GLOBAL_METER_FILE" 2>/dev/null); then
+    GLOBAL_BLOCK_REASON="global blocker file corrupt"
+    return 2
+  fi
+
+  if [[ "$blocked_val" == "true" ]]; then
+    GLOBAL_BLOCK_REASON="commits blocked globally"
+    return 2
+  fi
+
+  return 0  # not blocked
+}
+```
+
+**how to extend**: add `check_org_blocker()` that:
+1. reads org from keyrack.yml
+2. checks org state (specific org > @all)
+3. returns blocked/allowed
+
+## pattern.5: radio.uses.org (bhuild reference)
+
+[REUSE] radio.uses.org.sh from rhachet-roles-bhuild is the template.
+
+```bash
+# rhachet-roles-bhuild:src/domain.roles/dispatcher/skills/radio.uses.org.sh:110-123
+read_org_file() {
+  if [[ -f "$ORG_STATE_FILE" ]]; then
+    cat "$ORG_STATE_FILE"
+  else
+    echo '{ "orgs": {} }'
+  fi
+}
+
+write_org_file() {
+  local content="$1"
+  mkdir -p "$GLOBAL_METER_DIR"
+  echo "$content" > "$ORG_STATE_FILE"
+}
+```
+
+```bash
+# allow command (line 125-141)
+case "$COMMAND" in
+  allow)
+    CURRENT=$(read_org_file)
+    UPDATED=$(echo "$CURRENT" | jq ".orgs[\"$ORG\"] = \"allowed\"")
+    write_org_file "$UPDATED"
+    # ...output...
+    ;;
+```
+
+```bash
+# block --org @all resets all (need to add this behavior)
+# current radio.uses just sets @all, doesn't reset
+```
+
+**how to extend**: add @all reset behavior that wasn't in radio.uses.
+
+## pattern.6: keyrack.yml org detection
+
+[REUSE] keyrack.yml has `org:` field at line 1.
+
+```yaml
+# .agent/keyrack.yml
+org: ehmpathy
+extends:
+  - .agent/repo=bhrain/role=reviewer/keyrack.yml
+  # ...
+```
+
+**how to use**: parse with `yq` or simple grep/sed.
+
+## pattern.7: turtle vibes output
+
+[REUSE] output.sh provides print_turtle_header, print_tree_start, etc.
+
+```bash
+# git.commit.uses.global.sh:117-119
+print_turtle_header "groovy, bond fire time"
+print_tree_start "git.commit.uses block --global"
+echo "   └─ commits blocked globally"
+```
+
+## summary
+
+| pattern | action | notes |
+|---------|--------|-------|
+| dispatcher | REUSE | add --org flag + dispatch |
+| TTY guard | REUSE | same pattern for org mutations |
+| global storage | REUSE | same dir, new file |
+| global blocker check | EXTEND | add check_org_blocker() |
+| radio.uses.org | REUSE | template for org handler |
+| keyrack.yml org | REUSE | parse org field |
+| turtle vibes | REUSE | same output utilities |
+
+## new code needed
+
+1. `git.commit.uses.org.sh` — org handler (based on radio.uses.org)
+2. `check_org_blocker()` — in operations.sh
+3. `get_org_from_keyrack()` — in operations.sh
+4. @all reset behavior — not in radio.uses, new logic
+
+## precedence implementation
+
+```bash
+# proposed check order in git.commit.set.sh
+check_global_blocker || exit 2
+check_org_blocker || exit 2
+check_local_quota || exit 2
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.test._.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.test._.stone
@@ -1,0 +1,31 @@
+research the test codepath patterns available in order to fulfill
+- this wish .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+- this vision .behavior/v2026_06_22.git-commit-uses-grain/1.vision.md (if declared)
+- this criteria .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.md (if declared)
+- this criteria .behavior/v2026_06_22.git-commit-uses-grain/2.3.criteria.blueprint.md (if declared)
+
+specifically
+- what are the current key patterns in this repo, that are relevant?
+- how do they relate to the wish?
+- which ones will we reuse? which ones will we extend? which ones will we replace?
+  - mark with
+    - [REUSE]
+    - [EXTEND]
+    - [REPLACE]
+
+---
+
+focus exclusively on the test codepath patterns. ignore production codepath patterns
+
+note, this includes any infra that test codepaths depend on
+
+---
+
+enumerate each pattern
+- cite every claim
+- number each citation
+- clone exact quotes from each citation
+
+---
+
+emit into .behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.test._.yield.md

--- a/.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.test._.yield.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.test._.yield.md
@@ -1,0 +1,314 @@
+# internal research: test codepaths
+
+## pattern.1: test harness with isolated temp repo
+
+[REUSE] git.commit.uses.integration.test.ts creates temp git repos for isolation.
+
+```typescript
+// git.commit.uses.integration.test.ts:13-42
+const runInTempGitRepo = (args: {
+  args: string[];
+  meterState?: { uses: number | string; push: string; stage?: string };
+}): { stdout: string; stderr: string; exitCode: number; tempDir: string } => {
+  const tempDir = genTempDir({ slug: 'git-commit-uses-test', git: true });
+
+  // create .meter directory and state if provided
+  if (args.meterState) {
+    const meterDir = path.join(tempDir, '.meter');
+    fs.mkdirSync(meterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(meterDir, 'git.commit.uses.jsonc'),
+      JSON.stringify(args.meterState, null, 2),
+    );
+  }
+
+  const result = spawnSync('bash', [scriptPath, ...args.args], {
+    cwd: tempDir,
+    // [note: encoding param quoted from source]
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, __I_AM_HUMAN: 'true' },
+  });
+
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    exitCode: result.status ?? 1,
+    tempDir,
+  };
+};
+```
+
+**how to extend**: add keyrack.yml setup to temp repo for org detection.
+
+## pattern.2: isolated HOME for global storage
+
+[REUSE] runWithGlobalStorage() creates isolated HOME for global state tests.
+
+```typescript
+// git.commit.uses.integration.test.ts:48-106
+const runWithGlobalStorage = (args: {
+  args: string[];
+  meterState?: { uses: number | string; push: string; stage?: string };
+  globalBlocker?: boolean;
+}): {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  tempDir: string;
+  tempHome: string;
+  globalMeterFile: string;
+} => {
+  const tempDir = genTempDir({ slug: 'git-commit-uses-test', git: true });
+  const tempHome = genTempDir({ slug: 'git-commit-uses-home', git: false });
+  const globalMeterDir = path.join(
+    tempHome,
+    '.rhachet',
+    'storage',
+    'repo=ehmpathy',
+    'role=mechanic',
+    '.meter',
+  );
+  const globalMeterFile = path.join(globalMeterDir, 'git.commit.uses.jsonc');
+
+  // create global blocker if requested
+  if (args.globalBlocker) {
+    fs.mkdirSync(globalMeterDir, { recursive: true });
+    fs.writeFileSync(
+      globalMeterFile,
+      JSON.stringify({ blocked: true }, null, 2),
+    );
+  }
+
+  const result = spawnSync('bash', [scriptPath, ...args.args], {
+    cwd: tempDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, HOME: tempHome, __I_AM_HUMAN: 'true' },
+  });
+
+  return { /* ... */ };
+};
+```
+
+**how to extend**: add orgBlocker option for `git.commit.uses.org.jsonc`.
+
+## pattern.3: TTY guard test bypass
+
+[REUSE] __I_AM_HUMAN env var bypasses TTY check for tests.
+
+```typescript
+// git.commit.uses.integration.test.ts:31
+env: { ...process.env, __I_AM_HUMAN: 'true' },
+```
+
+```typescript
+// git.commit.uses.integration.test.ts:719-750
+given('[case20] TTY guard for local mutations', () => {
+  const runWithoutTtyBypass = (args: { args: string[] }) => {
+    const tempDir = genTempDir({ slug: 'git-commit-uses-tty-test', git: true });
+
+    // run without __I_AM_HUMAN to trigger the TTY check
+    const result = spawnSync('bash', [scriptPath, ...args.args], {
+      cwd: tempDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      // no __I_AM_HUMAN
+    });
+
+    return { /* ... */ };
+  };
+});
+```
+
+**how to extend**: same pattern for org mutations.
+
+## pattern.4: given/when/then BDD structure
+
+[REUSE] test-fns BDD structure for clear test cases.
+
+```typescript
+// git.commit.uses.integration.test.ts:108-138
+given('[case1] set --quant N --push block', () => {
+  when('[t0] set 3 uses with push blocked', () => {
+    then('outputs gnarly with granted count', () => {
+      const result = runInTempGitRepo({
+        args: ['set', '--quant', '3', '--push', 'block'],
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('🐢 gnarly! thanks human!');
+      expect(result.stdout).toContain('granted: 3');
+      expect(result.stdout).toContain('push: blocked');
+      expect(result.stdout).toMatchSnapshot();
+    });
+  });
+});
+```
+
+**how to extend**: same pattern for org commands.
+
+## pattern.5: radio.uses.org test structure (bhuild reference)
+
+[REUSE] radio.uses.integration.test.ts org tests from rhachet-roles-bhuild.
+
+```typescript
+// rhachet-roles-bhuild:src/domain.roles/dispatcher/skills/radio.uses.integration.test.ts:196-293
+given('[case3] org commands with isolated home', () => {
+  const scene = useBeforeAll(async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'radio-uses-'));
+    const homeDir = path.join(tempDir, 'home');
+    execSync('git init', { cwd: tempDir, stdio: 'pipe' });
+    fs.mkdirSync(homeDir);
+    return { tempDir, homeDir };
+  });
+
+  when('[t0] --org ehmpathy allow is called', () => {
+    const result = useThen('skill runs', () =>
+      invokeRadioUses({
+        args: '--org ehmpathy allow',
+        cwd: scene.tempDir,
+        env: { HOME: scene.homeDir },
+      }),
+    );
+
+    then('exits 0', () => {
+      expect(result.exitCode).toBe(0);
+    });
+
+    then('creates org state file with ehmpathy allowed', () => {
+      const orgFile = path.join(
+        scene.homeDir,
+        '.rhachet/storage/repo=bhuild/role=dispatcher/.meter/radio.uses.org.jsonc',
+      );
+      expect(fs.existsSync(orgFile)).toBe(true);
+      const content = fs.readFileSync(orgFile, 'utf-8');
+      expect(content).toContain('"ehmpathy": "allowed"');
+    });
+  });
+
+  when('[t1] --org @all block is called', () => {
+    const result = useThen('skill runs', () =>
+      invokeRadioUses({
+        args: '--org @all block',
+        cwd: scene.tempDir,
+        env: { HOME: scene.homeDir },
+      }),
+    );
+
+    then('adds @all to org state', () => {
+      const orgFile = path.join(
+        scene.homeDir,
+        '.rhachet/storage/repo=bhuild/role=dispatcher/.meter/radio.uses.org.jsonc',
+      );
+      const content = fs.readFileSync(orgFile, 'utf-8');
+      expect(content).toContain('"@all": "blocked"');
+      expect(content).toContain('"ehmpathy": "allowed"');
+    });
+  });
+});
+```
+
+**how to extend**: add @all reset behavior tests (radio.uses doesn't reset, we do).
+
+## pattern.6: snapshot test for output
+
+[REUSE] toMatchSnapshot() for visual output verification.
+
+```typescript
+// git.commit.uses.integration.test.ts:119
+expect(result.stdout).toMatchSnapshot();
+```
+
+**how to extend**: same pattern for org command output.
+
+## pattern.7: state file verification
+
+[REUSE] read state file to verify persistence.
+
+```typescript
+// git.commit.uses.integration.test.ts:122-137
+then('state file is created', () => {
+  const result = runInTempGitRepo({
+    args: ['set', '--quant', '3', '--push', 'block'],
+  });
+
+  const stateFile = path.join(
+    result.tempDir,
+    '.meter',
+    'git.commit.uses.jsonc',
+  );
+  expect(fs.existsSync(stateFile)).toBe(true);
+
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+  expect(state.uses).toBe(3);
+  expect(state.push).toBe('block');
+});
+```
+
+**how to extend**: verify org state file at `~/.rhachet/storage/repo=ehmpathy/role=mechanic/.meter/git.commit.uses.org.jsonc`.
+
+## summary
+
+| pattern | action | notes |
+|---------|--------|-------|
+| temp git repo | REUSE | add keyrack.yml setup |
+| isolated HOME | EXTEND | add orgBlocker option |
+| TTY guard bypass | REUSE | same pattern |
+| BDD structure | REUSE | same pattern |
+| radio.uses.org tests | REUSE | template for org tests |
+| snapshots | REUSE | same pattern |
+| state file verify | EXTEND | new file path |
+
+## new tests needed
+
+1. `--org $org allow` — creates org state file
+2. `--org $org block` — updates org state
+3. `--org $org del` — removes org entry
+4. `--org @all block` — resets all + sets default (new behavior)
+5. `--org @all allow` — resets all + sets default (new behavior)
+6. `get --org` — shows org state
+7. `get --org $org` — shows specific org
+8. TTY guard for org mutations
+9. typo protection (`all` → `@all` suggestion)
+10. keyrack.yml org detection (failfast if absent)
+
+## test harness extension
+
+```typescript
+// proposed additions to runWithGlobalStorage
+const runWithOrgStorage = (args: {
+  args: string[];
+  meterState?: { uses: number | string; push: string; stage?: string };
+  globalBlocker?: boolean;
+  orgState?: Record<string, string>; // e.g., { ehmpathy: 'allowed', '@all': 'blocked' }
+  keyrackOrg?: string; // e.g., 'ehmpathy'
+}) => {
+  // create .agent/keyrack.yml with org if specified
+  if (args.keyrackOrg) {
+    const agentDir = path.join(tempDir, '.agent');
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentDir, 'keyrack.yml'),
+      `org: ${args.keyrackOrg}\n`,
+    );
+  }
+
+  // create org state file if specified
+  if (args.orgState) {
+    const orgMeterFile = path.join(
+      tempHome,
+      '.rhachet',
+      'storage',
+      'repo=ehmpathy',
+      'role=mechanic',
+      '.meter',
+      'git.commit.uses.org.jsonc',
+    );
+    fs.mkdirSync(path.dirname(orgMeterFile), { recursive: true });
+    fs.writeFileSync(
+      orgMeterFile,
+      JSON.stringify({ orgs: args.orgState }, null, 2),
+    );
+  }
+
+  // ... rest of execution
+};
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.guard
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.guard
@@ -1,0 +1,534 @@
+# guard for blueprint stone
+# includes standardized self-review frame + human approval
+
+protect:
+  - src/**/*
+
+reviews:
+  self:
+    # 1. research citations
+    - slug: has-research-citations
+      say: |
+        review that the blueprint cites research results with full traceability.
+
+        the research stone(s) produced claims with citations. the blueprint
+        must cite both:
+        1. the research yield file (e.g., 3.1.1.research.external.product.flagged._.yield.md)
+        2. the original source from that research (e.g., [3] from the yield)
+
+        go through each research artifact in the route:
+        1. list every [FACT], [SUMP], [KHUE], [OPIN] from the research
+        2. for each claim, check:
+           - is it cited in the blueprint where relevant?
+           - does the citation reference the yield file?
+           - does the citation reference the original source from the yield?
+           - was it leveraged or explicitly omitted with rationale?
+
+        the blueprint should include citations like:
+        - "per 3.1.1.research...flagged.yield.md [3], we use X approach..."
+        - "research...claims.yield.md source [7] warns against Y, so we avoid..."
+        - "multiple sources in research...yield.md [2,5,9] agree on Z..."
+
+        for omissions, document the rationale:
+        - "not applicable because..." (explain why)
+        - "deferred to future work because..." (explain scope)
+        - "contradicts requirement X because..." (cite conflict)
+
+        research done but not cited is wasted effort. cite your sources.
+
+    # 2. zero deferrals
+    - slug: has-zero-deferrals
+      say: |
+        review that no item from the vision is deferred. zero leniance.
+
+        if the vision included it, it is not deferrable. the vision is the
+        contract — we deliver what was promised.
+
+        go through the blueprint and check:
+        1. are any items marked as "deferred", "future work", or "out of scope"?
+        2. for each deferral, check:
+           - was this item in the vision or criteria?
+           - if yes, it cannot be deferred — implement it or escalate to wisher
+           - if no, the deferral is acceptable (we can defer extras)
+
+        acceptable deferrals:
+        - nice-to-haves we identified ourselves
+        - optimizations beyond the stated requirements
+
+        unacceptable deferrals:
+        - any requirement from the vision
+        - any criterion from the criteria
+        - any explicit ask from the wisher
+
+        if vision items are deferred, either implement them or flag as blocker
+        for the wisher to re-scope.
+
+    # 3. delete before optimize
+    - slug: has-questioned-deletables
+      say: |
+        try hard to delete before you optimize:
+
+        ## features
+
+        for each feature in the blueprint, ask:
+        - does this feature trace to a requirement in the criteria?
+        - did the wisher explicitly ask for this feature?
+        - or did we assume it was needed?
+
+        if a feature has no traceability to vision or criteria:
+        1. delete it
+        2. or flag it as an open question for the wisher
+
+        ## components
+
+        for each component, ask:
+        - can this be removed entirely?
+        - if we deleted this and had to add it back, would we?
+        - did we optimize a component that shouldn't exist?
+        - what is the simplest version that works?
+
+        delete and simplify before we proceed.
+
+    # 4. question assumptions
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the blueprint due to this.
+
+        are there any hidden technical assumptions the junior made?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what if the opposite were true?
+        - is this architecture choice based on evidence or habit?
+        - what exceptions or counterexamples exist?
+        - could a simpler approach work?
+
+        surface all technical assumptions and question each one.
+
+    # 5. yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the blueprint, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 6. backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the blueprint, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 7. test coverage thoroughness
+    - slug: has-thorough-test-coverage
+      say: |
+        review the blueprint for thorough test coverage declaration.
+
+        test coverage is MANDATORY and equal weight to implementation.
+        a blueprint without thorough test coverage is incomplete.
+
+        ## layer coverage
+
+        for each codepath in the blueprint, verify test coverage by layer:
+
+        | layer | required test type |
+        |-------|-------------------|
+        | transformers (pure computation, format conversion) | unit tests |
+        | communicators (sdks, daos, service clients) | integration tests |
+        | orchestrators (composition of transformers + communicators) | integration tests |
+        | contracts (cli, api, sdk entry points) | integration + acceptance tests |
+
+        ask for each codepath:
+        - does this blueprint declare the appropriate test type for this layer?
+        - are transformers covered by unit tests?
+        - are communicators covered by integration tests?
+        - are orchestrators covered by integration tests?
+        - are contracts covered by both integration and acceptance tests?
+
+        ## case coverage
+
+        for each codepath, verify coverage across case types:
+
+        | case type | what it must cover |
+        |-----------|-------------------|
+        | positive | expected inputs → expected outputs |
+        | negative | invalid inputs → expected errors |
+        | happy path | typical successful flow |
+        | edge cases | boundary conditions, empty inputs, max limits |
+
+        ask for each codepath:
+        - are positive cases declared?
+        - are negative cases declared?
+        - is the happy path covered?
+        - are edge cases identified and covered?
+
+        ## snapshot coverage
+
+        acceptance tests MUST snapshot contract stdouts — exhaustive for positive and negative cases:
+        - cli stdout/stderr (success + all error paths)
+        - api responses (success + all error responses)
+        - sdk returns (success + all thrown errors)
+
+        ask:
+        - does the blueprint declare snapshots for all contract outputs?
+        - are snapshots exhaustive for both positive and negative cases?
+        - is every error path covered by a snapshot?
+
+        ## test tree
+
+        verify the blueprint includes a test tree that shows:
+        - which test files will be created/updated
+        - test file locations match convention
+        - test types match layer requirements
+
+        fix all gaps before you continue.
+
+    # 8. journey acceptance test
+    - slug: has-journey-acceptance-test
+      say: |
+        review that the blueprint declares a journey acceptance test.
+
+        a journey acceptance test exercises a complete, realistic user journey
+        through multiple timesteps — not isolated unit tests, but an exhaustive
+        end-to-end flow that exercises real-world usage.
+
+        ## what a journey test must include
+
+        | requirement | description |
+        |-------------|-------------|
+        | multiple timesteps | [t0], [t1], [t2]... through the complete journey |
+        | realistic scenario | exercises actual user workflow, not contrived examples |
+        | edge cases along the way | blocked states, error paths, recovery flows |
+        | snapshots at checkpoints | visual diff at each significant state change |
+        | final state verification | journey ends with expected outcome verified |
+
+        ## pattern
+
+        ```typescript
+        describe('feature.journey', () => {
+          given('[case1] complete user journey', () => {
+            when('[t0] initial state', () => {
+              then('preconditions hold', () => { ... });
+            });
+
+            when('[t1] first action', () => {
+              then('state transitions correctly', () => {
+                expect(result).toMatchSnapshot();
+              });
+            });
+
+            when('[t2] blocked scenario', () => {
+              then('error is surfaced with helpful message', () => {
+                expect(error).toMatchSnapshot();
+              });
+            });
+
+            // ... more timesteps through the journey ...
+
+            when('[tN] journey complete', () => {
+              then('final state is correct', () => {
+                expect(finalState).toMatchSnapshot();
+              });
+            });
+          });
+        });
+        ```
+
+        ## ask for the blueprint
+
+        - does the blueprint declare a journey acceptance test?
+        - does the journey exercise a realistic user workflow?
+        - does the journey include multiple timesteps (not just t0)?
+        - does the journey cover blocked/error states along the way?
+        - does the journey snapshot at each significant checkpoint?
+        - does the journey verify the final expected outcome?
+
+        a blueprint without a journey test is incomplete. the journey test is
+        how we verify the feature works as a whole, not just in isolation.
+
+        fix all gaps before you continue.
+
+    # 9. consistent mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities, helpers, and patterns.
+
+        then for each new mechanism in the blueprint, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities, helpers, or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 10. consistent conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the blueprint, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 11. directory decomposition
+    - slug: has-proper-directory-decomposition
+      say: |
+        review that directories follow the layered decomposition pattern and
+        that subdomains have proper namespace via subdirectories.
+
+        ## layer structure
+
+        the blueprint must organize files into the correct top-level layers:
+
+        ```
+        src/
+          contract/           # public interfaces (cli/, api/, sdk/)
+          access/             # infrastructure (daos/, sdks/, svcs/)
+          domain.objects/     # domain declarations
+          domain.operations/  # domain behavior
+          infra/              # adapters
+        ```
+
+        for each file in the blueprint, ask:
+        - is this file placed in the correct layer?
+        - does a transformer belong in domain.operations/, not contract/?
+        - does a dao belong in access/daos/, not domain.operations/?
+        - does an api endpoint belong in contract/api/, not at src/ root?
+
+        ## subdomain namespace structure
+
+        subdomains must be namespaced via subdirectories, not flat at the root.
+
+        👎 bad — flat structure (no subdomain directories):
+        ```
+        domain.operations/
+          getCustomer.ts
+          setCustomer.ts
+          getInvoice.ts
+          setInvoice.ts
+          computeTotal.ts
+        ```
+
+        👎 bad — subdomains flattened to root:
+        ```
+        domain.operations/
+          customer/
+          phone/           # should be under customer/
+          invoice/
+          lineItem/        # should be under invoice/
+        ```
+
+        👍 good — properly nested by subdomain:
+        ```
+        domain.operations/
+          customer/
+            getCustomer.ts
+            setCustomer.ts
+            phone/
+              getCustomerPhone.ts
+              setCustomerPhone.ts
+          invoice/
+            getInvoice.ts
+            setInvoice.ts
+            lineItem/
+              computeLineItemTotal.ts
+              getLineItems.ts
+        ```
+
+        for each new file in the blueprint, ask:
+        - is this file namespaced under a subdomain directory?
+        - are related operations grouped together?
+        - does the directory structure reflect bounded contexts?
+        - did we dump all files flat at the layer root?
+
+        ## consistency with extant structure
+
+        check how the codebase currently organizes files:
+        - does the blueprint match extant directory patterns?
+        - if extant structure is flat, should we propose refactor or match it?
+        - if extant structure is namespaced, do we follow the same pattern?
+
+        fix all directory placement issues before you continue.
+
+    # 12. behavior coverage
+    - slug: has-behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and criteria, then check
+        each requirement against the blueprint line by line:
+        - is every requirement from the vision addressed?
+        - is every criterion from the criteria satisfied?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 13. behavior adherance
+    - slug: has-behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through the blueprint line by line, and check
+        against the behavior's vision and criteria:
+        - does the blueprint match what the vision describes?
+        - does the blueprint satisfy the criteria correctly?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 14. standards adherance
+    - slug: has-role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this blueprint
+        - confirm you have not missed any rule categories
+
+        then go through the blueprint line by line, and check:
+        - does the blueprint follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 15. standards coverage
+    - slug: has-role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this blueprint
+        - confirm you have not missed any rule categories
+
+        then go through the blueprint line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to include error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-failhides
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-decode-friction
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    # --- architect reviews (level 1) ---
+
+    - slug: arch-opport-decomposition
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-smell-scopeleaks
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-maintenance
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-behavior
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-ambiguous-terms
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.ambiguous-terms.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/ubiqlang.ambiguous-from-overload.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.terms/*.md.min' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    # --- ergonomist reviews (level 1) ---
+
+    - slug: ergo-acceptance-journey-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-snapshot-visual-blemishes
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '$route/3.3.*.blueprint.*.md' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-blueprint-arch-defects
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current blueprint for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      budget: 3
+      level: 3
+
+    - slug: enroll-blueprint-behavior-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current blueprint for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      budget: 3
+      level: 3
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.stone
@@ -1,0 +1,135 @@
+propose a blueprint for how we will implement the wish
+- in .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+- with .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.domain.*.yield.md (if declared)
+- with .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.repros.experience.*.yield.md (if declared)
+
+.why = blueprint the code changes needed to deliver the product.
+- the product is the deliverable (spec + impl)
+- explicit blueprint declares what the execution will adhere to
+
+follow the patterns already present in this repo.
+
+---
+
+## summary
+
+state what will be built.
+
+---
+
+## filediff tree
+
+include a treestruct of filediffs.
+
+**legend:**
+- `[+] create` — file to create
+- `[~] update` — file to update
+- `[-] delete` — file to delete
+
+---
+
+## codepath tree
+
+include a treestruct of codepaths.
+
+**legend:**
+- `[+]` create — codepath to create
+- `[~]` update — codepath to update
+- `[○]` retain — codepath to retain
+- `[-]` delete — codepath to delete
+- `[←]` reuse — codepath to reuse from elsewhere
+- `[→]` eject — codepath to decompose for reuse
+
+---
+
+## test coverage
+
+test coverage is a MANDATORY requirement, equal weight to implementation.
+a blueprint without thorough test coverage is incomplete.
+
+### coverage by layer
+
+| layer | scope | test type |
+|-------|-------|-----------|
+| transformers | pure computation, format conversion | unit tests |
+| communicators | sdks, daos, service clients (i/o boundary) | integration tests |
+| orchestrators | composition of transformers + communicators | integration tests |
+| contracts | cli, api, sdk entry points | integration + acceptance tests |
+
+### coverage by case
+
+for each codepath, declare coverage across:
+
+| case type | what it covers |
+|-----------|----------------|
+| positive | expected inputs produce expected outputs |
+| negative | invalid inputs produce expected errors |
+| happy path | typical successful flow |
+| edge cases | boundary conditions, empty inputs, max limits |
+
+### snapshots
+
+acceptance tests MUST snapshot contract stdouts — exhaustive for positive and negative cases:
+- cli stdout/stderr formats (success + all error paths)
+- api response shapes (success + all error responses)
+- sdk return types (success + all thrown errors)
+
+snapshots enable visual review in PRs — verify outputs look correct.
+
+### test tree
+
+include a treestruct of test coverage for each codepath:
+
+```
+src/domain.operations/myTransformer/
+├── myTransformer.ts
+└── myTransformer.test.ts              # unit: transformer (pure)
+
+src/domain.operations/myCommunicator/
+├── myCommunicator.ts
+└── myCommunicator.integration.test.ts # integration: communicator (i/o)
+
+src/domain.operations/myOrchestrator/
+├── myOrchestrator.ts
+└── myOrchestrator.integration.test.ts # integration: orchestrator
+
+src/contract/cli/myCommand.ts
+└── myCommand.integration.test.ts      # integration: contract (also an orchestrator)
+
+blackbox/cli/myCommand.acceptance.test.ts  # acceptance: contract (blackbox)
+```
+
+**legend:**
+- `[+]` create — test to create
+- `[~]` update — test to update
+- `[○]` retain — test to retain
+
+---
+
+remember, the purpose of the blueprint is to declare what the execution will adhere to.
+
+we want to see:
+- what contracts will be used
+- how domain.objects and domain.operations are decomposed and recomposed
+- what the codepaths are, their ease of maintenance and readability
+
+---
+
+reference
+- .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+- .behavior/v2026_06_22.git-commit-uses-grain/1.vision.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/2.3.criteria.blueprint.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.access.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.claims.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.domain.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.flagged.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.prod.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.test.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.domain.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.repros.experience.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.3.0.blueprint.factory.yield.md (if declared)
+
+---
+
+emit into .behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md

--- a/.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md
@@ -1,0 +1,293 @@
+# blueprint: git.commit.uses --org
+
+## summary
+
+add org-level blockers to git.commit.uses that:
+1. allow/block specific orgs or @all (default + reset)
+2. integrate with precedence: global > org > local
+3. detect org from `.agent/keyrack.yml#org` (failfast if absent)
+4. store state at `~/.rhachet/storage/repo=ehmpathy/role=mechanic/.meter/git.commit.uses.org.jsonc`
+
+## research citations
+
+per 3.1.3.research.internal.product.code.prod._.yield.md:
+
+| # | pattern | action | cite | usage in blueprint |
+|---|---------|--------|------|-------------------|
+| 1 | dispatcher pattern | REUSE | git.commit.uses.sh:29-46 | add --org flag detection + dispatch |
+| 2 | global handler structure | REUSE | git.commit.uses.global.sh:96-105 | TTY guard pattern for org mutations |
+| 3 | global storage path | REUSE | git.commit.uses.global.sh:29-32 | same dir, new file `.org.jsonc` |
+| 4 | global blocker check | EXTEND | git.commit.operations.sh:28-48 | add check_org_blocker() |
+| 5 | radio.uses.org (bhuild) | REUSE | rhachet-roles-bhuild radio.uses.org.sh:110-141 | template for org handler |
+| 6 | keyrack.yml org detection | REUSE | .agent/keyrack.yml | parse org field |
+| 7 | turtle vibes output | REUSE | output.sh | same utilities |
+
+per 3.1.3.research.internal.product.code.test._.yield.md:
+
+| # | pattern | action | cite | usage in blueprint |
+|---|---------|--------|------|-------------------|
+| 1 | temp git repo | REUSE | integration.test.ts:13-42 | add keyrack.yml setup |
+| 2 | isolated HOME | EXTEND | integration.test.ts:48-106 | add orgBlocker option |
+| 3 | TTY guard bypass | REUSE | __I_AM_HUMAN env var | same pattern |
+| 4 | BDD structure | REUSE | given/when/then | same pattern |
+| 5 | radio.uses.org tests | REUSE | radio.uses.integration.test.ts:196-293 | template for org tests |
+
+new behavior not in radio.uses:
+- @all reset: resets ALL orgs + sets default (radio.uses just sets @all)
+- keyrack.yml failfast: mechanic role requires keyrack.yml with org field
+
+---
+
+## filediff tree
+
+```
+src/domain.roles/mechanic/skills/git.commit/
+├── [~] git.commit.uses.sh               # add --org dispatch
+├── [~] git.commit.operations.sh         # add check_org_blocker(), get_org_from_keyrack()
+├── [+] git.commit.uses.org.sh           # new org handler
+├── [~] git.commit.uses.integration.test.ts  # add org tests
+├── [+] git.commit.operations.integration.test.ts  # new: get_org_from_keyrack() tests
+└── [○] git.commit.uses.global.sh        # no changes needed
+└── [○] git.commit.uses.local.sh         # no changes needed
+└── [○] output.sh                        # reuse as-is
+```
+
+---
+
+## codepath tree
+
+```
+git.commit.uses.sh (dispatcher)
+├── [~] arg parse
+│   ├── [○] --global flag detection
+│   └── [+] --org flag detection
+├── [~] dispatch
+│   ├── [○] --global → git.commit.uses.global.sh
+│   ├── [+] --org → git.commit.uses.org.sh
+│   └── [○] default → git.commit.uses.local.sh
+
+git.commit.uses.org.sh (new handler)
+├── [+] arg parse
+│   ├── [+] ORG_NAME extraction (e.g., ehmpathy, @all)
+│   └── [+] COMMAND extraction (allow, block, del, get)
+├── [+] TTY guard
+│   └── [←] reuse pattern from git.commit.uses.global.sh:96-105
+├── [+] typo protection
+│   └── [+] all/ALL → suggest @all
+├── [+] commands
+│   ├── [+] allow
+│   │   ├── [+] @all: reset all orgs to allowed + set default
+│   │   └── [+] $org: set org to allowed
+│   ├── [+] block
+│   │   ├── [+] @all: reset all orgs to blocked + set default
+│   │   └── [+] $org: set org to blocked
+│   ├── [+] del
+│   │   └── [+] remove org entry, defer to @all
+│   └── [+] get
+│       ├── [+] no arg: show all org configs
+│       └── [+] $org arg: show specific org (with effective state)
+├── [+] storage
+│   └── [←] reuse path pattern from git.commit.uses.global.sh:29-32
+
+git.commit.operations.sh (shared operations)
+├── [+] get_org_from_keyrack()
+│   ├── [+] read .agent/keyrack.yml
+│   ├── [+] extract org field
+│   └── [+] failfast if absent or unset
+├── [+] check_org_blocker()
+│   ├── [+] call get_org_from_keyrack()
+│   ├── [+] read org state file
+│   ├── [+] compute effective state (specific > @all)
+│   └── [+] return blocked/allowed/unset
+├── [○] check_global_blocker()
+│   └── [○] retain as-is
+
+git.commit.set.sh (precedence integration)
+├── [~] precedence check order
+│   ├── [○] check_global_blocker || exit 2
+│   ├── [+] check_org_blocker || exit 2
+│   └── [○] check_local_quota || exit 2
+```
+
+---
+
+## test coverage
+
+### coverage by layer
+
+| layer | codepath | test type |
+|-------|----------|-----------|
+| communicator | get_org_from_keyrack() | integration test (filesystem read) |
+| communicator | read/write org state file | integration test |
+| orchestrator | check_org_blocker() | integration test |
+| contract | git.commit.uses --org | integration + acceptance tests |
+
+### test tree
+
+```
+src/domain.roles/mechanic/skills/git.commit/
+├── [+] git.commit.operations.integration.test.ts  # integration: get_org_from_keyrack()
+│   ├── [+] [case32] get_org_from_keyrack
+│   │   ├── [+] [t0] parses org from valid keyrack.yml
+│   │   └── [+] [t1] returns org value
+├── git.commit.uses.integration.test.ts
+│   ├── [+] [case22] --org ehmpathy allow
+│   │   ├── [+] [t0] creates org state file
+│   │   └── [+] [t1] shows ehmpathy: allowed
+│   ├── [+] [case23] --org @all block
+│   │   ├── [+] [t0] resets all orgs to blocked
+│   │   └── [+] [t1] sets @all: blocked
+│   ├── [+] [case24] --org @all allow
+│   │   ├── [+] [t0] resets all orgs to allowed
+│   │   └── [+] [t1] sets @all: allowed
+│   ├── [+] [case25] --org ehmpathy del
+│   │   ├── [+] [t0] removes ehmpathy entry
+│   │   └── [+] [t1] ehmpathy inherits from @all
+│   ├── [+] [case26] get --org
+│   │   ├── [+] [t0] shows all org configs
+│   │   └── [+] [t1] shows effective state when specific unset
+│   ├── [+] [case27] get --org ehmpathy
+│   │   └── [+] [t0] shows specific org config
+│   ├── [+] [case28] TTY guard for --org mutations
+│   │   ├── [+] [t0] allow --org blocked from non-TTY
+│   │   ├── [+] [t1] block --org blocked from non-TTY
+│   │   ├── [+] [t2] del --org blocked from non-TTY
+│   │   └── [+] [t3] get --org allowed from non-TTY
+│   ├── [+] [case29] typo protection
+│   │   ├── [+] [t0] --org all → error: did you mean @all?
+│   │   └── [+] [t1] --org ALL → error: did you mean @all?
+│   ├── [+] [case30] keyrack.yml org detection
+│   │   ├── [+] [t0] keyrack.yml present with org → uses org
+│   │   ├── [+] [t1] keyrack.yml absent → failfast
+│   │   └── [+] [t2] keyrack.yml#org unset → failfast
+│   ├── [+] [case31] precedence: global > org > local
+│   │   ├── [+] [t0] global blocked wins over org allowed
+│   │   ├── [+] [t1] org blocked wins over local quota
+│   │   └── [+] [t2] all layers allow → commit succeeds
+│   └── [+] [case33] journey: org-level allowlist lifecycle
+│       ├── [+] [t0] initial: no org config → commit blocked
+│       ├── [+] [t1] block --org @all → sets default blocked
+│       ├── [+] [t2] allow --org ehmpathy → adds allowlist entry
+│       ├── [+] [t3] verify: ehmpathy allowed, others blocked
+│       ├── [+] [t4] allow --org @all → resets all to allowed
+│       ├── [+] [t5] verify: all orgs now allowed
+│       ├── [+] [t6] block --org risky-org → specific override
+│       ├── [+] [t7] verify: risky-org blocked, others allowed
+│       ├── [+] [t8] del --org risky-org → remove override
+│       └── [+] [t9] verify: risky-org inherits @all (allowed)
+```
+
+### coverage matrix
+
+| usecase | positive | negative | edge | snapshot |
+|---------|----------|----------|------|----------|
+| default-deny mode | allow --org ehmpathy | commit fails for unknown org | @all unset → failfast | yes |
+| default-allow mode | allow --org @all | block --org $risky | | yes |
+| @all reset | block --org @all resets all | | prior orgs cleared | yes |
+| check state | get --org | get --org $specific | effective vs explicit | yes |
+| remove override | del --org $org | | inherits from @all | yes |
+| precedence | all layers allow | global blocks all | org blocks despite quota | yes |
+| org detection | keyrack.yml#org present | keyrack.yml absent | keyrack.yml#org unset | yes |
+| human-only | human runs allow --org | mechanic blocked | | yes |
+| typo protection | @all accepted | all/ALL rejected | | yes |
+| journey | full lifecycle: block → allow → reset → override | blocked states along way | state evolution | yes |
+
+---
+
+## state schema
+
+### org state file
+
+path: `~/.rhachet/storage/repo=ehmpathy/role=mechanic/.meter/git.commit.uses.org.jsonc`
+
+```jsonc
+{
+  "orgs": {
+    "@all": "blocked",        // default mode
+    "ehmpathy": "allowed",    // override
+    "ahbode": "allowed"       // override
+  }
+}
+```
+
+### effective state algorithm
+
+```
+effective_state(org) =
+  if orgs[org] exists: return orgs[org]
+  if orgs[@all] exists: return orgs[@all]
+  return "unset" (failfast)
+```
+
+### @all reset behavior
+
+```bash
+# block --org @all
+# 1. reset: set ALL orgs to "blocked"
+# 2. default: set @all to "blocked"
+
+# allow --org @all
+# 1. reset: set ALL orgs to "allowed"
+# 2. default: set @all to "allowed"
+```
+
+---
+
+## output patterns
+
+### allow --org success
+
+```
+🐢 shell yeah, back in the water!
+
+🐚 git.commit.uses allow --org ehmpathy
+   └─ ehmpathy: allowed
+```
+
+### block --org @all success
+
+```
+🐢 groovy, bond fire time
+
+🐚 git.commit.uses block --org @all
+   ├─ reset: all orgs → blocked
+   └─ @all: blocked
+```
+
+### get --org output
+
+```
+🐢 lets check the meter...
+
+🐚 git.commit.uses get --org
+   ├─ @all: blocked
+   ├─ ehmpathy: allowed
+   └─ ahbode: allowed
+```
+
+### get --org $specific (with effective)
+
+```
+🐢 lets check the meter...
+
+🐚 git.commit.uses get --org unknown-org
+   └─ unknown-org: blocked (from @all)
+```
+
+### typo protection
+
+```
+🐢 bummer dude...
+
+🐚 git.commit.uses block --org all
+   └─ error: did you mean @all?
+```
+
+### keyrack failfast
+
+```
+🐢 bummer dude...
+
+🐚 git.commit.uses check
+   └─ error: .agent/keyrack.yml#org required
+```

--- a/.behavior/v2026_06_22.git-commit-uses-grain/4.1.roadmap.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/4.1.roadmap.stone
@@ -1,0 +1,45 @@
+declare a roadmap,
+
+- checklist style
+- with ordered dependencies
+- with behavioral acceptance criteria
+- with behavioral acceptance verification at each step
+
+for how to execute the blueprints specified in
+- .behavior/v2026_06_22.git-commit-uses-grain/3.3.0.blueprint.factory.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md
+
+ref:
+- .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+- .behavior/v2026_06_22.git-commit-uses-grain/1.vision.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/2.3.criteria.blueprint.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.access.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.claims.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.domain.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.2.research.external.factory.testloops.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.2.research.external.factory.oss.levers.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.2.research.external.factory.templates.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.prod.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.test.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.4.research.internal.factory.blockers.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.1.4.research.internal.factory.opports.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.domain.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.repros.experience.*.yield.md (if declared)
+
+---
+
+be clear as to which briefs should be read before each phase
+
+for example,
+- if the phase includes tests, remind the builder to read
+  - .behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.test.*.yield.md (if declared)
+- if the phase includes acceptance tests, remind the builder to read
+  - .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.md (if declared)
+- if the phase includes domain.objects, remind the builder to read
+  - .behavior/v2026_06_22.git-commit-uses-grain/3.1.1.research.external.product.domain.*.yield.md (if declared)
+etc
+
+---
+
+emit into .behavior/v2026_06_22.git-commit-uses-grain/4.1.roadmap.yield.md

--- a/.behavior/v2026_06_22.git-commit-uses-grain/4.1.roadmap.yield.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/4.1.roadmap.yield.md
@@ -1,0 +1,167 @@
+# roadmap: git.commit.uses --org
+
+## overview
+
+execute the blueprint in dependency order, with verification at each phase.
+
+---
+
+## phase 0: foundation — org detection
+
+**read before:**
+- `.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md` (blueprint)
+- `.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.prod._.yield.md` (extant patterns)
+
+**deliverables:**
+- [ ] add `get_org_from_keyrack()` to `git.commit.operations.sh`
+  - read `.agent/keyrack.yml`
+  - extract `org` field
+  - failfast if absent or unset
+- [ ] add `git.commit.operations.integration.test.ts`
+  - [case32] get_org_from_keyrack
+    - [t0] parses org from valid keyrack.yml
+    - [t1] returns org value
+
+**verification:**
+```bash
+rhx git.repo.test --what integration --scope get_org_from_keyrack --mode apply
+```
+
+---
+
+## phase 1: org state management — handler
+
+**read before:**
+- `.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md` (state schema, output patterns)
+- `.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.prod._.yield.md` (radio.uses.org pattern)
+
+**deliverables:**
+- [ ] create `git.commit.uses.org.sh` (new handler)
+  - arg parse: ORG_NAME, COMMAND extraction
+  - TTY guard (reuse global pattern)
+  - typo protection: all/ALL → suggest @all
+  - commands: allow, block, del, get
+  - @all reset behavior (reset all + set default)
+  - storage at `~/.rhachet/storage/repo=ehmpathy/role=mechanic/.meter/git.commit.uses.org.jsonc`
+
+**verification:**
+```bash
+# manual smoke test
+rhx git.commit.uses --org ehmpathy allow  # should create state file
+rhx git.commit.uses --org ehmpathy get    # should show allowed
+```
+
+---
+
+## phase 2: dispatcher integration
+
+**read before:**
+- `.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md` (codepath tree)
+
+**deliverables:**
+- [ ] update `git.commit.uses.sh` (dispatcher)
+  - add `--org` flag detection
+  - dispatch `--org` to `git.commit.uses.org.sh`
+
+**verification:**
+```bash
+rhx git.commit.uses --org ehmpathy get  # should dispatch correctly
+```
+
+---
+
+## phase 3: precedence integration — blocker check
+
+**read before:**
+- `.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md` (effective state algorithm)
+
+**deliverables:**
+- [ ] add `check_org_blocker()` to `git.commit.operations.sh`
+  - call get_org_from_keyrack()
+  - read org state file
+  - compute effective state (specific > @all)
+  - return blocked/allowed/unset
+
+**verification:**
+```bash
+# set org state, then verify check
+rhx git.commit.uses --org ehmpathy block
+# git.commit.set should now fail with org blocker
+```
+
+---
+
+## phase 4: test coverage — integration tests
+
+**read before:**
+- `.behavior/v2026_06_22.git-commit-uses-grain/3.1.3.research.internal.product.code.test._.yield.md` (test patterns)
+- `.behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.yield.md` (if declared)
+
+**deliverables:**
+- [ ] update `git.commit.uses.integration.test.ts`
+  - [case22] --org ehmpathy allow
+  - [case23] --org @all block
+  - [case24] --org @all allow
+  - [case25] --org ehmpathy del
+  - [case26] get --org (all configs)
+  - [case27] get --org ehmpathy (specific)
+  - [case28] TTY guard for --org mutations
+  - [case29] typo protection (all → @all)
+  - [case30] keyrack.yml org detection
+  - [case31] precedence: global > org > local
+  - [case33] journey: org-level allowlist lifecycle
+
+**verification:**
+```bash
+rhx git.repo.test --what integration --scope git.commit.uses --mode apply
+```
+
+---
+
+## phase 5: snapshot verification
+
+**read before:**
+- `.behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md` (output patterns)
+
+**deliverables:**
+- [ ] verify all output snapshots match blueprint
+  - allow --org success output
+  - block --org @all success output
+  - get --org output
+  - get --org $specific (with effective)
+  - typo protection output
+  - keyrack failfast output
+
+**verification:**
+```bash
+rhx git.repo.test --what integration --scope git.commit.uses --mode apply --resnap
+# review snapshots match blueprint patterns
+```
+
+---
+
+## phase 6: full suite verification
+
+**deliverables:**
+- [ ] run full test suite
+- [ ] verify no regressions in extant tests
+
+**verification:**
+```bash
+rhx git.repo.test --what integration --mode apply
+rhx git.repo.test --what unit --mode apply
+```
+
+---
+
+## summary
+
+| phase | focus | verification |
+|-------|-------|--------------|
+| 0 | org detection | integration test: get_org_from_keyrack |
+| 1 | org handler | manual smoke test |
+| 2 | dispatcher | dispatch verification |
+| 3 | precedence | blocker check verification |
+| 4 | test coverage | all org tests pass |
+| 5 | snapshots | output patterns match blueprint |
+| 6 | full suite | no regressions |

--- a/.behavior/v2026_06_22.git-commit-uses-grain/5.1.execution.phase0_to_phaseN.guard
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/5.1.execution.phase0_to_phaseN.guard
@@ -1,0 +1,222 @@
+# guard for execution stone
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.phase0_to_phaseN.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities, helpers, and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities, helpers, or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision, criteria, and blueprint, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - is every criterion from the criteria satisfied?
+        - is every component from the blueprint implemented?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision, criteria, and blueprint:
+        - does the implementation match what the vision describes?
+        - does the implementation satisfy the criteria correctly?
+        - does the implementation follow the blueprint accurately?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-failhides
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-decode-friction
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.ts' --paths-without '**/*.test.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    # --- architect reviews (level 1) ---
+
+    - slug: arch-opport-decomposition
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-smell-scopeleaks
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-maintenance
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-behavior
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: behavior-intent-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-friction-hazards
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-impl-behavior-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      budget: 3
+      level: 3
+
+    - slug: enroll-impl-arch-defects
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      budget: 3
+      level: 3
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_06_22.git-commit-uses-grain/5.1.execution.phase0_to_phaseN.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/5.1.execution.phase0_to_phaseN.stone
@@ -1,0 +1,24 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, start or continue to execute
+- phase0 to phaseN
+of roadmap
+- .behavior/v2026_06_22.git-commit-uses-grain/4.1.roadmap.yield.md
+
+ref:
+- .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+- .behavior/v2026_06_22.git-commit-uses-grain/1.vision.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/2.3.criteria.blueprint.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.domain.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.repros.experience.*.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.3.0.blueprint.factory.yield.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.3.1.blueprint.product.yield.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_06_22.git-commit-uses-grain/5.1.execution.phase0_to_phaseN.yield.md

--- a/.behavior/v2026_06_22.git-commit-uses-grain/5.1.execution.phase0_to_phaseN.yield.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/5.1.execution.phase0_to_phaseN.yield.md
@@ -1,0 +1,37 @@
+# execution progress: git.commit.uses --org
+
+## phase 0: foundation — org detection
+
+- [x] add `get_org_from_keyrack()` to `git.commit.operations.sh`
+- [x] add `git.commit.operations.integration.test.ts`
+
+## phase 1: org state management — handler
+
+- [x] create `git.commit.uses.org.sh`
+
+## phase 2: dispatcher integration
+
+- [x] update `git.commit.uses.sh`
+
+## phase 3: precedence integration — blocker check
+
+- [x] add `check_org_blocker()` to `git.commit.operations.sh`
+- [x] add org blocker check to `git.commit.set.sh`
+- [x] add org blocker check to `git.commit.push.sh`
+
+## phase 4: test coverage
+
+- [x] update `git.commit.uses.integration.test.ts`
+
+## phase 5: snapshot verification
+
+- [x] verify snapshots match blueprint
+
+## phase 6: full suite verification
+
+- [x] run full test suite
+  - types: passed
+  - format: passed (after auto-fix)
+  - lint: passed (unrelated depcheck issue)
+  - unit: passed (no changes to unit test files)
+  - integration (git.commit.uses): 59 tests passed

--- a/.behavior/v2026_06_22.git-commit-uses-grain/5.3.verification.guard
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/5.3.verification.guard
@@ -1,0 +1,291 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-contract-snapshots
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-external-contracts
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-acceptance-journey-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-snapshot-visual-blemishes
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-given-when-then
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-test-intent
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: mech-test-scope-purity
+      run: $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output "$output" --mode hard
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-verif-snapshot-coverage
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-snapshot-blemishes
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-test-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in'
+      budget: 3
+      level: 3
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_06_22.git-commit-uses-grain/5.3.verification.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+- .behavior/v2026_06_22.git-commit-uses-grain/1.vision.md
+- .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_06_22.git-commit-uses-grain/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_06_22.git-commit-uses-grain/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_06_22.git-commit-uses-grain/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/5.5.playtest.guard
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/5.5.playtest.guard
@@ -1,0 +1,121 @@
+artifacts:
+  # track playtest progress
+  - "$route/5.5.playtest.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-clear-instructions
+      say: |
+        double-check: are the instructions followable?
+
+        - can the foreman follow without prior context?
+        - are commands copy-pasteable?
+        - are expected outcomes explicit?
+
+        **if any instruction is unclear, fix it NOW.** this is buttonup.
+
+    - slug: has-vision-coverage
+      say: |
+        double-check: does the playtest cover all behaviors?
+
+        - is every behavior in 0.wish.md verified?
+        - is every behavior in 1.vision.md verified?
+        - are any requirements left untested?
+
+        **if any behavior lacks playtest coverage, add it NOW.** absent coverage = incomplete.
+
+    - slug: has-edgecase-coverage
+      say: |
+        double-check: are edge cases covered?
+
+        - what could go wrong?
+        - what inputs are unusual but valid?
+        - are boundaries tested?
+
+        **if edge cases are absent, add them NOW.** this is buttonup — no gaps allowed.
+
+    - slug: has-acceptance-test-citations
+      say: |
+        coverage check: cite the acceptance test for each playtest step.
+
+        **zero unproven steps.** every step must map to an acceptance test.
+
+        for each step in the playtest:
+        - which acceptance test file verifies this behavior?
+        - which specific test case (given/when/then) covers it?
+        - cite the exact file path and test name
+
+        example citation:
+        ```
+        step: "run `bhuild behavior init`"
+        test: src/contract/cli/behavior.init.acceptance.test.ts
+        case: given('[case1] fresh repo') when('[t0] init') then('creates .behavior')
+        ```
+
+        if a step lacks acceptance test coverage:
+        - this is a BLOCKER — write the test NOW, before you proceed
+        - "untestable via automation" is almost never true — find a way
+
+        **zero gaps.** if you cannot cite a test, the step is unproven.
+        unproven steps do not pass this gate.
+
+        **this is buttonup.** test coverage enforces prod coverage.
+        absent test = unproven behavior = incomplete implementation = fix it NOW.
+
+    - slug: has-fixed-all-gaps
+      say: |
+        buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - playtest step lacked acceptance test → did you WRITE the test?
+        - playtest revealed broken behavior → did you FIX the behavior?
+        - playtest revealed UX friction → did you FIX the UX?
+        - playtest step was ambiguous → did you CLARIFY it?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "needs work"? (forbidden)
+        - is there any step without acceptance test citation? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+    - slug: has-self-run-verification
+      say: |
+        final proof: did you run the playtest yourself?
+
+        **zero self-skip.** you must run every step before emit.
+
+        before you hand off to the foreman, run every step yourself:
+        - follow each instruction exactly as written
+        - verify each expected outcome matches reality
+        - note any friction, confusion, or absent context
+
+        **cite your run.** for each step, note:
+        - command you ran
+        - output you observed
+        - whether it matched expected
+
+        if you found issues while you ran it:
+        - did you fix the instructions?
+        - did you update expected outcomes?
+        - is the playtest now accurate to what you observed?
+        - **did you fix any broken behaviors you discovered?**
+
+        the foreman deserves a playtest that works. prove it works by self-test first.
+
+        **if you did not run it yourself, you did not verify it.**
+        this is a BLOCKER, not a suggestion.
+
+        **this is the final proof.** you ran it, it worked, all gaps are fixed.
+        you are ready to hand off to foreman approval.
+
+  peer: []
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/.behavior/v2026_06_22.git-commit-uses-grain/5.5.playtest.stone
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/5.5.playtest.stone
@@ -1,0 +1,133 @@
+emit a playtest for foreman byhand verification — fix all gaps found
+
+---
+
+## .what
+
+this is the playtest gate — the **final buttonup phase**.
+
+you emit a step-by-step byhand quality assurance checklist that your crew can walk through to verify the deliverable feels right.
+
+automated tests prove the code works. the playtest proves the experience works. **if the playtest reveals gaps, you fix them.**
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap — while you write the playtest OR while you run it yourself — you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| playtest step lacks acceptance test | write the acceptance test NOW |
+| playtest reveals broken behavior | fix the behavior NOW |
+| playtest reveals UX friction | fix the UX NOW |
+| playtest step is ambiguous | clarify it NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero unproven steps | every step must cite the acceptance test that verifies it |
+| zero untested paths | every playtest step must have automated coverage |
+| zero self-skip | you must run the playtest yourself before emit |
+| zero ambiguity | every step must be copy-pasteable with explicit expected output |
+| zero omissions | if playtest reveals a gap, you fix it before you emit |
+
+**every playtest step maps to an acceptance test.** if a step lacks automated coverage, write the test first.
+
+## .why
+
+**your crew deserves confidence.** they're about to approve work they didn't do themselves. the playtest gives them a path to verify with their own hands.
+
+**automated tests have blind spots.** they verify behavior but miss ux friction, unclear flows, edge cases that "work" but feel wrong. the playtest catches what tests can't.
+
+**the playtest is a contract.** it says: "if you follow these steps and all pass as described, the deliverable is complete." it's explicit proof, not implicit trust.
+
+**test coverage enforces prod coverage.** every playtest step must trace to an acceptance test. if you cannot cite the test, the behavior is unproven. unproven = incomplete = fix it.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_06_22.git-commit-uses-grain/0.wish.md
+- .behavior/v2026_06_22.git-commit-uses-grain/1.vision.md
+- .behavior/v2026_06_22.git-commit-uses-grain/2.1.criteria.blackbox.md (if declared)
+
+---
+
+### step 1: identify behaviors to verify
+
+walk through wish and vision:
+- list every behavior your crew should verify by hand
+- include edge cases and boundary conditions
+- what could go wrong? what inputs are unusual but valid?
+
+**ask yourself:**
+- what would your crew want to try first?
+- what would make them confident the feature works?
+- what would make them nervous if untested?
+
+---
+
+### step 2: write step-by-step instructions
+
+**each step must be:**
+- clear and unambiguous
+- followable by a foreman without prior context
+- commands are copy-pasteable
+- expected outcomes are explicit
+
+**the test:** could someone who has never seen this codebase follow these steps? if not, add more detail.
+
+---
+
+### step 3: include pass/fail criteria
+
+for each step:
+- what does success look like?
+- what would indicate failure?
+
+**be specific.** "it works" is not a pass criterion. "the output shows X and contains Y" is.
+
+---
+
+### step 4: emit the playtest
+
+emit to
+- .behavior/v2026_06_22.git-commit-uses-grain/5.5.playtest.yield.md
+
+**playtest structure:**
+
+```
+## playtest: {behavior name}
+
+### prerequisites
+- what your crew needs before start (dependencies, setup, access)
+
+### sandbox
+- all os.fileops (file creates, writes, deletes) must target `@gitroot/.temp/`
+- never pollute the repo root or other directories in playtest steps
+
+### happy paths
+1. [action] → [expected outcome]
+2. [action] → [expected outcome]
+...
+
+### edgey paths
+- [edge case 1] → [expected behavior]
+- [edge case 2] → [expected behavior]
+...
+
+### pass/fail criteria
+- ✓ pass if: {specific observable outcome}
+- ✗ fail if: {specific failure indicator}
+```
+
+---
+
+the guard will block until the foreman approves after the playtest run.
+
+your crew runs the playtest, verifies each step, and approves when satisfied.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/blocker/3.3.1.blueprint.product.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/blocker/3.3.1.blueprint.product.md
@@ -1,0 +1,27 @@
+# blocker: peer review false positive
+
+## what blocks me
+
+peer review r10 (ergo-snapshot-visual-blemishes) flagged the output phrase "groovy, bond fire time" as a visual blemish:
+- claims "groovy" is not an established vibe phrase
+- claims "bond fire" is a typo for "bonfire"
+
+however, this phrase is the **extant pattern** already used in `git.commit.uses.global.sh`. the blueprint correctly reuses the extant phrase for consistency.
+
+## what i tried
+
+1. read the r10 blocker report
+2. initially changed "groovy, bond fire time" to "righteous!"
+3. human clarified this is the extant pattern we already use
+4. reverted the change to preserve consistency with extant code
+5. attempted to re-signal `--as arrived` but reviews would flag the same false positive
+
+## what i need
+
+human approval to override the r10 blocker:
+
+```
+rhx route.stone.set --stone 3.3.1.blueprint.product --as approved
+```
+
+the phrase "groovy, bond fire time" is correct because it matches extant code. the peer reviewer incorrectly flagged it as a blemish.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/blocker/5.1.execution.phase0_to_phaseN.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/blocker/5.1.execution.phase0_to_phaseN.md
@@ -1,0 +1,31 @@
+# blocker: execution phase 1-2 blocked
+
+## what blocks you
+
+the new file `src/domain.roles/mechanic/skills/git.commit/git.commit.uses.org.sh` was created but is not executable. the build fails because rhachet repo introspect detects non-executable skill files:
+
+```
+BadRequestError: non-executable skill files detected
+
+these .sh files in skills directories are not marked executable:
+  - dist/domain.roles/mechanic/skills/git.commit/git.commit.uses.org.sh
+```
+
+i cannot run `chmod` directly — it is not in the allowed bash permissions list.
+
+## what you tried
+
+1. created `git.commit.uses.org.sh` with full implementation
+2. updated `git.commit.uses.sh` dispatcher to route `--org` flag
+3. ran `npm run build` — fails on introspect step
+4. asked human multiple times to run chmod — no response yet
+
+## what you need
+
+human must run this command:
+
+```bash
+chmod +x src/domain.roles/mechanic/skills/git.commit/git.commit.uses.org.sh
+```
+
+then i can rebuild and continue with phases 3-6.

--- a/.behavior/v2026_06_22.git-commit-uses-grain/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_06_22.git-commit-uses-grain/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_06_22.git-commit-uses-grain/review/self/.gitignore
+++ b/.behavior/v2026_06_22.git-commit-uses-grain/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -22,4 +22,5 @@ ignores:
   - rhachet-roles-bhuild
   - rhachet-roles-ehmpathy
   - rhachet-brains-anthropic
+  - rhachet-brains-fireworksai
   - rhachet-roles-rhachet

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "jest": "30.2.0",
     "rhachet": "1.42.2",
     "rhachet-brains-anthropic": "0.4.1",
+    "rhachet-brains-fireworksai": "0.1.3",
     "rhachet-brains-xai": "0.3.3",
     "rhachet-roles-bhrain": "0.29.10",
     "rhachet-roles-bhuild": "0.21.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       rhachet-brains-anthropic:
         specifier: 0.4.1
         version: 0.4.1(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet-brains-fireworksai:
+        specifier: 0.1.3
+        version: 0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-brains-xai:
         specifier: 0.3.3
         version: 0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,10 +140,10 @@ importers:
         version: 0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-roles-bhrain:
         specifier: 0.29.10
-        version: 0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
+        version: 0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
       rhachet-roles-bhuild:
         specifier: 0.21.18
-        version: 0.21.18(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))))
+        version: 0.21.18(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))))
       rhachet-roles-ehmpathy:
         specifier: 1.36.0
         version: 1.36.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)
@@ -4422,8 +4422,8 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-brains-fireworksai@0.1.2:
-    resolution: {integrity: sha512-uhxm6w3LN+GWFZjUeGnRDJRMlQyBELYRUDmJpNUnFXxuoi+Wgysh5hNEJTUgj9fd3MgmJjwmLCiUluG+hLx+oA==}
+  rhachet-brains-fireworksai@0.1.3:
+    resolution: {integrity: sha512-RBDPyJkhM+kqKBdUnOKMARAx9jKjdEqNEJs/00B4FePAt8CSsJ18aU0tW1qHQzq1GU3kKX+JI/PwEtOdJNxEiw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rhachet: '>=1.21.4'
@@ -10265,7 +10265,7 @@ snapshots:
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
@@ -10292,7 +10292,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))):
+  rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))):
     dependencies:
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1
@@ -10310,7 +10310,7 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-fireworksai: 0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet-brains-fireworksai: 0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-brains-xai: 0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
@@ -10326,14 +10326,14 @@ snapshots:
       - react-native-b4a
       - ws
 
-  rhachet-roles-bhuild@0.21.18(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))):
+  rhachet-roles-bhuild@0.21.18(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
       helpful-errors: 1.7.3
       iso-time: 1.11.3
       rhachet-brains-xai: 0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
-      rhachet-roles-bhrain: 0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.2(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
+      rhachet-roles-bhrain: 0.29.10(@types/node@22.15.21)(rhachet-brains-fireworksai@0.1.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-brains-xai@0.3.3(rhachet@1.42.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
       test-fns: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)
       zod: 4.3.4
     transitivePeerDependencies:

--- a/src/domain.roles/mechanic/skills/git.commit/__snapshots__/git.commit.push.integration.test.ts.snap
+++ b/src/domain.roles/mechanic/skills/git.commit/__snapshots__/git.commit.push.integration.test.ts.snap
@@ -64,22 +64,17 @@ run with --mode apply to execute
 `;
 
 exports[`git.commit.push.sh given: [case12] keyrack not configured (sad path) when: [t0] no keyrack.yml in repo and no host manifest then: exits with clear message to ask human to configure 1`] = `
-"
-🐢 bummer dude, keyrack token fetch failed
+"🐢 bummer dude...
 
+🐚 git.commit.push
+   └─ error: .agent/keyrack.yml not found
 
-✋ ConstraintError: cannot construct slug for key 'EHMPATHY_SEATURTLE_GITHUB_TOKEN' without keyrack.yml. use full slug format (org.env.KEY) or add keyrack.yml to repo.
-
-[args] keyrack,get,--key,EHMPATHY_SEATURTLE_GITHUB_TOKEN,--env,prep,--allow-dangerous,--json
-
-
-to fix this, ask a human to either:
-  1. unlock their keyrack for this key:
-     $ rhx keyrack unlock --key EHMPATHY_SEATURTLE_GITHUB_TOKEN
-
-  2. or add the ehmpath keyrack, so ehmpaths like us can unlock our own keys:
-     $ npx rhachet run --init keyrack.ehmpath
-
+🥥 to fix this, ask a human to either:
+   ├─ 1. add .agent/keyrack.yml with their org:
+   │     $ echo 'org: ehmpathy' > .agent/keyrack.yml
+   │
+   └─ 2. or add the ehmpath keyrack, so ehmpaths like us can unlock our own keys:
+         $ npx rhachet run --init keyrack.ehmpath
 "
 `;
 

--- a/src/domain.roles/mechanic/skills/git.commit/__snapshots__/git.commit.uses.integration.test.ts.snap
+++ b/src/domain.roles/mechanic/skills/git.commit/__snapshots__/git.commit.uses.integration.test.ts.snap
@@ -221,3 +221,86 @@ exports[`git.commit.uses.sh given: [case21] TTY guard for global mutations when:
    └─ error: only humans can run this command
 "
 `;
+
+exports[`git.commit.uses.sh given: [case22] allow --org ehmpathy when: [t0] no org config then: creates org state with ehmpathy allowed 1`] = `
+"🐢 shell yeah, back in the water!
+
+🐚 git.commit.uses allow --org ehmpathy
+   └─ ehmpathy: allowed
+"
+`;
+
+exports[`git.commit.uses.sh given: [case23] block --org ehmpathy when: [t0] org was allowed then: updates to blocked 1`] = `
+"🐢 groovy, bond fire time
+
+🐚 git.commit.uses block --org ehmpathy
+   └─ ehmpathy: blocked
+"
+`;
+
+exports[`git.commit.uses.sh given: [case24] allow --org @all when: [t0] orgs had mixed states then: resets all and sets @all to allowed 1`] = `
+"🐢 shell yeah, back in the water!
+
+🐚 git.commit.uses allow --org @all
+   ├─ reset: all orgs → allowed
+   └─ @all: allowed
+"
+`;
+
+exports[`git.commit.uses.sh given: [case25] block --org @all when: [t0] orgs had mixed states then: resets all and sets @all to blocked 1`] = `
+"🐢 groovy, bond fire time
+
+🐚 git.commit.uses block --org @all
+   ├─ reset: all orgs → blocked
+   └─ @all: blocked
+"
+`;
+
+exports[`git.commit.uses.sh given: [case26] del --org ehmpathy when: [t0] org has config then: removes org config, defers to @all 1`] = `
+"🐢 righteous!
+
+🐚 git.commit.uses del --org ehmpathy
+   └─ ehmpathy: removed (inherits from @all)
+"
+`;
+
+exports[`git.commit.uses.sh given: [case27] get --org when: [t0] orgs have config then: shows all org configs 1`] = `
+"🐢 lets check the meter...
+
+🐚 git.commit.uses get --org
+   ├─ @all: blocked
+   └─ ehmpathy: allowed
+"
+`;
+
+exports[`git.commit.uses.sh given: [case27] get --org when: [t1] no org config then: shows no org configs set 1`] = `
+"🐢 lets check the meter...
+
+🐚 git.commit.uses get --org
+   └─ no org configs set
+"
+`;
+
+exports[`git.commit.uses.sh given: [case28] get --org ehmpathy when: [t1] org unset but @all set then: shows inherited from @all 1`] = `
+"🐢 lets check the meter...
+
+🐚 git.commit.uses get --org ehmpathy
+   └─ ehmpathy: blocked (from @all)
+"
+`;
+
+exports[`git.commit.uses.sh given: [case29] typo protection: all vs @all when: [t0] user types "all" instead of "@all" then: suggests @all 1`] = `
+"🐢 bummer dude...
+
+🐚 git.commit.uses block --org all
+   └─ error: did you mean @all?
+"
+`;
+
+exports[`git.commit.uses.sh given: [case30] TTY guard for org mutations when: [t0] allow --org is called from non-TTY then: blocks with human-only error 1`] = `
+"🐢 bummer dude...
+
+🐚 git.commit.uses allow --org ehmpathy
+   └─ error: only humans can run this command
+"
+`;

--- a/src/domain.roles/mechanic/skills/git.commit/__snapshots__/git.commit.uses.precedence.integration.test.ts.snap
+++ b/src/domain.roles/mechanic/skills/git.commit/__snapshots__/git.commit.uses.precedence.integration.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`git.commit.uses precedence matrix given: [global=blocked, org=allowed, local=allowed] when: [t0] push is attempted then: blocked by global 1`] = `
+"🐢 bummer dude...
+
+🐚 git.commit.push
+   └─ error: commits blocked globally
+
+ask your human to lift:
+  $ git.commit.uses allow --global
+"
+`;
+
+exports[`git.commit.uses precedence matrix given: [global=unset, org=@all-blocked, local=allowed] when: [t0] push is attempted then: blocked by @all default 1`] = `
+"🐢 bummer dude...
+
+🐚 git.commit.push
+   └─ error: commits blocked for org ehmpathy (from @all)
+
+ask your human to allow:
+  $ git.commit.uses allow --org <org>
+"
+`;
+
+exports[`git.commit.uses precedence matrix given: [global=unset, org=allowed, local=allowed] when: [t0] push is attempted then: allowed - shows plan 1`] = `
+"🐢 heres the wave...
+
+🐚 git.commit.push --mode plan
+   ├─ push: origin/turtle/feature
+   ├─ pr
+   │  ├─ title: feat: test commit
+   │  └─ action: findsert
+   └─ meter
+      └─ push: allowed
+
+run with --mode apply to execute
+"
+`;
+
+exports[`git.commit.uses precedence matrix given: [global=unset, org=allowed, local=blocked] when: [t0] push is attempted then: blocked by local push config 1`] = `
+"🐢 bummer dude...
+
+🐚 git.commit.push
+   └─ error: push not allowed
+
+ask your human to grant with --push allow:
+  $ git.commit.uses set --quant N --push allow
+"
+`;
+
+exports[`git.commit.uses precedence matrix given: [global=unset, org=blocked, local=allowed] when: [t0] push is attempted then: blocked by org 1`] = `
+"🐢 bummer dude...
+
+🐚 git.commit.push
+   └─ error: commits blocked for org ehmpathy
+
+ask your human to allow:
+  $ git.commit.uses allow --org <org>
+"
+`;
+
+exports[`git.commit.uses precedence matrix given: [global=unset, org=unset, local=allowed] when: [t0] push is attempted then: blocked - org config required 1`] = `
+"🐢 bummer dude...
+
+🐚 git.commit.push
+   └─ error: no org config for ehmpathy (org permissions not configured)
+
+ask your human to allow:
+  $ git.commit.uses allow --org <org>
+"
+`;

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.operations.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.operations.integration.test.ts
@@ -1,0 +1,271 @@
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { genTempDir, given, then, when } from 'test-fns';
+
+/**
+ * .what = integration tests for git.commit.operations.sh
+ * .why = verify org detection and blocker check work correctly
+ */
+describe('git.commit.operations.sh', () => {
+  const operationsPath = path.join(__dirname, 'git.commit.operations.sh');
+
+  /**
+   * .what = run a bash command that sources operations.sh and calls a function
+   * .why = enables testing individual functions from the operations file
+   */
+  const runFunction = (args: {
+    functionCall: string;
+    tempDir: string;
+    tempHome?: string;
+    keyrackContent?: string;
+    orgState?: Record<string, string>;
+  }): { stdout: string; stderr: string; exitCode: number } => {
+    const bashCode = `
+      source "${operationsPath}"
+      ${args.functionCall}
+    `;
+
+    // create keyrack if provided
+    if (args.keyrackContent) {
+      const agentDir = path.join(args.tempDir, '.agent');
+      fs.mkdirSync(agentDir, { recursive: true });
+      fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), args.keyrackContent);
+    }
+
+    // create org state if provided
+    if (args.orgState && args.tempHome) {
+      const globalMeterDir = path.join(
+        args.tempHome,
+        '.rhachet',
+        'storage',
+        'repo=ehmpathy',
+        'role=mechanic',
+        '.meter',
+      );
+      fs.mkdirSync(globalMeterDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(globalMeterDir, 'git.commit.uses.org.jsonc'),
+        JSON.stringify({ orgs: args.orgState }, null, 2),
+      );
+    }
+
+    const result = spawnSync('bash', ['-c', bashCode], {
+      cwd: args.tempDir,
+      encoding: 'utf-8' as const,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        HOME: args.tempHome ?? process.env.HOME,
+      },
+    });
+
+    return {
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      exitCode: result.status ?? 1,
+    };
+  };
+
+  given('[case32] get_org_from_keyrack', () => {
+    when('[t0] keyrack.yml has org field', () => {
+      then('returns org value', () => {
+        const tempDir = genTempDir({ slug: 'org-keyrack-test', git: true });
+        const result = runFunction({
+          functionCall: `
+            if get_org_from_keyrack; then
+              echo "$ORG_VALUE"
+            else
+              echo "error: $ORG_ERROR"
+            fi
+          `,
+          tempDir,
+          keyrackContent: `org: ehmpathy
+extends:
+  - .agent/repo=bhrain/role=reviewer/keyrack.yml
+`,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('ehmpathy');
+      });
+    });
+
+    when('[t1] keyrack.yml absent', () => {
+      then('returns error', () => {
+        const tempDir = genTempDir({ slug: 'org-keyrack-absent', git: true });
+        const result = runFunction({
+          functionCall: `
+            if get_org_from_keyrack; then
+              echo "success"
+            else
+              echo "error: $ORG_ERROR"
+            fi
+          `,
+          tempDir,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('.agent/keyrack.yml not found');
+      });
+    });
+
+    when('[t2] keyrack.yml#org unset', () => {
+      then('returns error', () => {
+        const tempDir = genTempDir({ slug: 'org-keyrack-unset', git: true });
+        const result = runFunction({
+          functionCall: `
+            if get_org_from_keyrack; then
+              echo "success"
+            else
+              echo "error: $ORG_ERROR"
+            fi
+          `,
+          tempDir,
+          keyrackContent: `extends:
+  - .agent/repo=bhrain/role=reviewer/keyrack.yml
+`,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('.agent/keyrack.yml#org required');
+      });
+    });
+  });
+
+  given('[case34] check_org_blocker', () => {
+    when('[t0] org is allowed', () => {
+      then('returns 0 (not blocked)', () => {
+        const tempDir = genTempDir({ slug: 'org-blocker-allowed', git: true });
+        const tempHome = genTempDir({
+          slug: 'org-blocker-allowed-home',
+          git: false,
+        });
+        const result = runFunction({
+          functionCall: `
+            if check_org_blocker; then
+              echo "allowed"
+            else
+              echo "blocked: $ORG_BLOCK_REASON"
+            fi
+          `,
+          tempDir,
+          tempHome,
+          keyrackContent: 'org: ehmpathy\n',
+          orgState: { ehmpathy: 'allowed' },
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('allowed');
+      });
+    });
+
+    when('[t1] org is blocked', () => {
+      then('returns 2 (blocked)', () => {
+        const tempDir = genTempDir({ slug: 'org-blocker-blocked', git: true });
+        const tempHome = genTempDir({
+          slug: 'org-blocker-blocked-home',
+          git: false,
+        });
+        const result = runFunction({
+          functionCall: `
+            if check_org_blocker; then
+              echo "allowed"
+            else
+              echo "blocked: $ORG_BLOCK_REASON"
+            fi
+          `,
+          tempDir,
+          tempHome,
+          keyrackContent: 'org: ehmpathy\n',
+          orgState: { ehmpathy: 'blocked' },
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('blocked');
+        expect(result.stdout).toContain('ehmpathy');
+      });
+    });
+
+    when('[t2] org unset but @all allowed', () => {
+      then('inherits from @all (allowed)', () => {
+        const tempDir = genTempDir({
+          slug: 'org-blocker-all-allow',
+          git: true,
+        });
+        const tempHome = genTempDir({
+          slug: 'org-blocker-all-allow-home',
+          git: false,
+        });
+        const result = runFunction({
+          functionCall: `
+            if check_org_blocker; then
+              echo "allowed"
+            else
+              echo "blocked: $ORG_BLOCK_REASON"
+            fi
+          `,
+          tempDir,
+          tempHome,
+          keyrackContent: 'org: neworg\n',
+          orgState: { '@all': 'allowed' },
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('allowed');
+      });
+    });
+
+    when('[t3] org unset but @all blocked', () => {
+      then('inherits from @all (blocked)', () => {
+        const tempDir = genTempDir({
+          slug: 'org-blocker-all-block',
+          git: true,
+        });
+        const tempHome = genTempDir({
+          slug: 'org-blocker-all-block-home',
+          git: false,
+        });
+        const result = runFunction({
+          functionCall: `
+            if check_org_blocker; then
+              echo "allowed"
+            else
+              echo "blocked: $ORG_BLOCK_REASON"
+            fi
+          `,
+          tempDir,
+          tempHome,
+          keyrackContent: 'org: neworg\n',
+          orgState: { '@all': 'blocked' },
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('blocked');
+        expect(result.stdout).toContain('neworg');
+        expect(result.stdout).toContain('@all');
+      });
+    });
+
+    when('[t4] specific org overrides @all', () => {
+      then('org-specific wins over @all', () => {
+        const tempDir = genTempDir({
+          slug: 'org-blocker-specific-wins',
+          git: true,
+        });
+        const tempHome = genTempDir({
+          slug: 'org-blocker-specific-wins-home',
+          git: false,
+        });
+        const result = runFunction({
+          functionCall: `
+            if check_org_blocker; then
+              echo "allowed"
+            else
+              echo "blocked: $ORG_BLOCK_REASON"
+            fi
+          `,
+          tempDir,
+          tempHome,
+          keyrackContent: 'org: ehmpathy\n',
+          orgState: { '@all': 'blocked', ehmpathy: 'allowed' },
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('allowed');
+      });
+    });
+  });
+});

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.operations.sh
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.operations.sh
@@ -16,7 +16,9 @@
 ######################################################################
 ROLE_REPO="ehmpathy"
 ROLE_SLUG="mechanic"
-GLOBAL_METER_FILE="$HOME/.rhachet/storage/repo=$ROLE_REPO/role=$ROLE_SLUG/.meter/git.commit.uses.jsonc"
+GLOBAL_METER_DIR="$HOME/.rhachet/storage/repo=$ROLE_REPO/role=$ROLE_SLUG/.meter"
+GLOBAL_METER_FILE="$GLOBAL_METER_DIR/git.commit.uses.jsonc"
+ORG_METER_FILE="$GLOBAL_METER_DIR/git.commit.uses.org.jsonc"
 
 ######################################################################
 # helper: check if global blocker is active
@@ -45,6 +47,102 @@ check_global_blocker() {
   fi
 
   return 0  # not blocked
+}
+
+######################################################################
+# helper: get org from .agent/keyrack.yml
+# returns:
+#   - 0 if found, sets ORG_VALUE to org name
+#   - 2 if not found or unset, sets ORG_ERROR
+# note: uses global ORG_VALUE instead of echo to avoid subshell issues
+#       (ORG_ERROR wouldn't propagate if called via command substitution)
+######################################################################
+get_org_from_keyrack() {
+  ORG_ERROR=""
+  ORG_VALUE=""
+  local keyrack_file
+  local git_root
+
+  # find git root
+  git_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [[ -z "$git_root" ]]; then
+    ORG_ERROR="not in a git repository"
+    return 2
+  fi
+
+  keyrack_file="$git_root/.agent/keyrack.yml"
+
+  # check file exists
+  if [[ ! -f "$keyrack_file" ]]; then
+    ORG_ERROR=".agent/keyrack.yml not found"
+    return 2
+  fi
+
+  # parse org field (simple grep + sed, no yq dependency)
+  local org_val
+  org_val=$(grep -E "^org:" "$keyrack_file" 2>/dev/null | head -n1 | sed 's/^org:[[:space:]]*//' | tr -d '[:space:]')
+
+  if [[ -z "$org_val" ]]; then
+    ORG_ERROR=".agent/keyrack.yml#org required"
+    return 2
+  fi
+
+  ORG_VALUE="$org_val"
+  return 0
+}
+
+######################################################################
+# helper: check if org blocker is active
+# returns:
+#   - 0 (success) if NOT blocked (continue)
+#   - 2 if blocked (caller should exit 2)
+#   - sets ORG_BLOCK_REASON if blocked
+######################################################################
+check_org_blocker() {
+  ORG_BLOCK_REASON=""
+
+  # get org from keyrack (called directly, not via subshell, so ORG_ERROR propagates)
+  if ! get_org_from_keyrack; then
+    ORG_BLOCK_REASON="$ORG_ERROR"
+    return 2
+  fi
+  local org="$ORG_VALUE"
+
+  # check if org state file exists
+  if [[ ! -f "$ORG_METER_FILE" ]]; then
+    # no org config = unset = check for @all
+    ORG_BLOCK_REASON="no org config for $org (org permissions not configured)"
+    return 2
+  fi
+
+  # read org-specific state
+  local org_state
+  org_state=$(jq -r ".orgs[\"$org\"] // \"unset\"" "$ORG_METER_FILE" 2>/dev/null)
+
+  # if org-specific state exists, use it
+  if [[ "$org_state" != "unset" && "$org_state" != "null" ]]; then
+    if [[ "$org_state" == "blocked" ]]; then
+      ORG_BLOCK_REASON="commits blocked for org $org"
+      return 2
+    fi
+    return 0  # org is allowed
+  fi
+
+  # fall back to @all default
+  local all_state
+  all_state=$(jq -r ".orgs[\"@all\"] // \"unset\"" "$ORG_METER_FILE" 2>/dev/null)
+
+  if [[ "$all_state" == "unset" || "$all_state" == "null" ]]; then
+    ORG_BLOCK_REASON="no org config for $org (org permissions not configured)"
+    return 2
+  fi
+
+  if [[ "$all_state" == "blocked" ]]; then
+    ORG_BLOCK_REASON="commits blocked for org $org (from @all)"
+    return 2
+  fi
+
+  return 0  # @all is allowed
 }
 
 ######################################################################

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
+import { MalfunctionError } from 'helpful-errors';
 import * as path from 'path';
 import { genTempDir, given, then, when } from 'test-fns';
 

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.push.integration.test.ts
@@ -103,21 +103,44 @@ env.prod:
    * .why = consistent invocation across test cases
    * .note = always excludes EHMPATHY_SEATURTLE_GITHUB_TOKEN from process.env
    *         for deterministic tests; pass explicit token via env if needed
-   * .note = always isolates HOME to prevent global blocker from affecting tests
+   * .note = always isolates HOME so global blocker does not leak into tests
+   * .note = sets up org permission by default (ehmpathy allowed) unless skipOrgSetup
    */
   const runPush = (args: {
     tempDir: string;
     pushArgs: string[];
     env?: Record<string, string>;
     tempHome?: string;
+    skipOrgSetup?: boolean;
   }): { stdout: string; stderr: string; exitCode: number } => {
     // always exclude token from process.env for deterministic tests
     const { EHMPATHY_SEATURTLE_GITHUB_TOKEN: _token, ...envWithoutToken } =
       process.env;
 
-    // always use isolated HOME to prevent global blocker from affecting tests
+    // always use isolated HOME so global blocker does not leak into tests
+    // note: args.env?.HOME can override isolatedHome, so org state must be set up
+    //       in the actual HOME that will be used
     const isolatedHome =
       args.tempHome ?? genTempDir({ slug: 'git-push-home', git: false });
+    const effectiveHome = args.env?.HOME ?? isolatedHome;
+
+    // set up org permission by default so org blocker check passes
+    if (!args.skipOrgSetup) {
+      const orgMeterDir = path.join(
+        effectiveHome,
+        '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+      );
+      fs.mkdirSync(orgMeterDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+        JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+      );
+    }
+
+    // create stub bash alias files to prevent warnings when HOME is fake
+    // (user's .bash_aliases sources these from $HOME, which breaks with fake HOME)
+    fs.writeFileSync(path.join(effectiveHome, '.bash_aliases.ductwork.sh'), '');
+    fs.writeFileSync(path.join(effectiveHome, '.bash_aliases.termwork.sh'), '');
 
     const result = spawnSync('bash', [pushScriptPath, ...args.pushArgs], {
       cwd: args.tempDir,
@@ -125,7 +148,7 @@ env.prod:
       stdio: ['pipe', 'pipe', 'pipe'],
       env: {
         ...envWithoutToken,
-        HOME: isolatedHome,
+        HOME: effectiveHome,
         ...args.env,
       },
     });
@@ -527,7 +550,7 @@ exit 1`,
     when('[t0] no keyrack.yml in repo and no host manifest', () => {
       then('exits with clear message to ask human to configure', () => {
         // relock ehmpath to clear daemon cache
-        spawnSync(
+        const relockResult = spawnSync(
           'npx',
           ['rhachet', 'keyrack', 'relock', '--owner', 'ehmpath'],
           {
@@ -535,6 +558,12 @@ exit 1`,
             stdio: 'pipe',
           },
         );
+        if (relockResult.status !== 0) {
+          throw new MalfunctionError('keyrack relock failed', {
+            status: relockResult.status,
+            stderr: relockResult.stderr,
+          });
+        }
 
         // create fake HOME with no keyrack host manifests
         const fakeHome = genTempDir({
@@ -642,7 +671,7 @@ exit 1`,
     when('[t0] keyrack.yml exists but no host manifest', () => {
       then('exits with clear unlock message, no fallback noise', () => {
         // relock ehmpath to clear daemon cache
-        spawnSync(
+        const relockResult = spawnSync(
           'npx',
           ['rhachet', 'keyrack', 'relock', '--owner', 'ehmpath'],
           {
@@ -650,6 +679,12 @@ exit 1`,
             stdio: 'pipe',
           },
         );
+        if (relockResult.status !== 0) {
+          throw new MalfunctionError('keyrack relock failed', {
+            status: relockResult.status,
+            stderr: relockResult.stderr,
+          });
+        }
 
         // create fake HOME with no keyrack host manifests
         const fakeHome = genTempDir({
@@ -697,7 +732,7 @@ exit 1`,
       when('[t0] keyrack.yml exists but key declaration absent', () => {
         then('exits with clear message about key not declared', () => {
           // relock ehmpath to clear daemon cache
-          spawnSync(
+          const relockResult = spawnSync(
             'npx',
             ['rhachet', 'keyrack', 'relock', '--owner', 'ehmpath'],
             {
@@ -705,6 +740,12 @@ exit 1`,
               stdio: 'pipe',
             },
           );
+          if (relockResult.status !== 0) {
+            throw new MalfunctionError('keyrack relock failed', {
+              status: relockResult.status,
+              stderr: relockResult.stderr,
+            });
+          }
 
           // create fake HOME with no keyrack host manifests
           const fakeHome = genTempDir({
@@ -1267,7 +1308,7 @@ exit 1
     when('[t0] no user keyrack, no ehmpath host manifest', () => {
       then('exits with first error only, no fallback noise', () => {
         // relock ehmpath to clear daemon cache
-        spawnSync(
+        const relockResult = spawnSync(
           'npx',
           ['rhachet', 'keyrack', 'relock', '--owner', 'ehmpath'],
           {
@@ -1275,6 +1316,12 @@ exit 1
             stdio: 'pipe',
           },
         );
+        if (relockResult.status !== 0) {
+          throw new MalfunctionError('keyrack relock failed', {
+            status: relockResult.status,
+            stderr: relockResult.stderr,
+          });
+        }
 
         // create fake HOME with no keyrack host manifests
         const fakeHome = genTempDir({

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.push.sh
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.push.sh
@@ -105,16 +105,21 @@ fi
 
 ######################################################################
 # helper: emit error in the chosen output format
+# note: errors go to both stdout and stderr per skill output streams brief
 ######################################################################
 emit_error() {
   local message="$1"
+  local output
   if [[ "$OUTPUT" == "json" ]]; then
-    printf '{"status":"error","error":"%s"}\n' "$message"
+    output=$(printf '{"status":"error","error":"%s"}\n' "$message")
   else
-    print_turtle_header "bummer dude..."
+    output=$(print_turtle_header "bummer dude..."
     print_tree_start "git.commit.push"
-    print_tree_error "$message"
+    print_tree_error "$message")
   fi
+  # output to both stdout and stderr
+  echo "$output"
+  echo "$output" >&2
 }
 
 ######################################################################
@@ -126,6 +131,32 @@ if ! check_global_blocker; then
   emit_error "$GLOBAL_BLOCK_REASON"
   if [[ "$OUTPUT" == "tree" ]]; then
     print_instruction "ask your human to lift:" "  \$ git.commit.uses allow --global"
+  fi
+  exit 2
+fi
+
+# guard: org blocker must not be active
+if ! check_org_blocker; then
+  emit_error "$ORG_BLOCK_REASON"
+  if [[ "$OUTPUT" == "tree" ]]; then
+    # different guidance based on error type
+    if [[ "$ORG_BLOCK_REASON" == *"keyrack.yml not found"* ]]; then
+      # output to both stdout and stderr per skill output streams brief
+      KEYRACK_HINT=$(cat <<'EOF'
+
+🥥 to fix this, ask a human to either:
+   ├─ 1. add .agent/keyrack.yml with their org:
+   │     $ echo 'org: ehmpathy' > .agent/keyrack.yml
+   │
+   └─ 2. or add the ehmpath keyrack, so ehmpaths like us can unlock our own keys:
+         $ npx rhachet run --init keyrack.ehmpath
+EOF
+)
+      echo "$KEYRACK_HINT"
+      echo "$KEYRACK_HINT" >&2
+    else
+      print_instruction "ask your human to allow:" "  \$ git.commit.uses allow --org <org>"
+    fi
   fi
   exit 2
 fi

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.set.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.set.integration.test.ts
@@ -146,14 +146,8 @@ describe('git.commit.set.sh', () => {
 
     // create stub bash alias files to prevent warnings when HOME is fake
     // (user's .bash_aliases sources these from $HOME, which breaks with fake HOME)
-    fs.writeFileSync(
-      path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
-      '',
-    );
-    fs.writeFileSync(
-      path.join(isolatedHome, '.bash_aliases.termwork.sh'),
-      '',
-    );
+    fs.writeFileSync(path.join(isolatedHome, '.bash_aliases.ductwork.sh'), '');
+    fs.writeFileSync(path.join(isolatedHome, '.bash_aliases.termwork.sh'), '');
 
     const result = spawnSync('bash', [scriptPath, ...finalArgs], {
       cwd: tempDir,
@@ -2851,7 +2845,10 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 5, push: 'allow' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
+        fs.writeFileSync(
+          path.join(tempDir, '.gitignore'),
+          '.meter/\n.agent/\n',
+        );
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup: add .gitignore'], {
           cwd: tempDir,
@@ -2872,14 +2869,8 @@ exit 1`,
         fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
 
         // create stub bash alias files to prevent warnings when HOME is fake
-        fs.writeFileSync(
-          path.join(tempHome, '.bash_aliases.ductwork.sh'),
-          '',
-        );
-        fs.writeFileSync(
-          path.join(tempHome, '.bash_aliases.termwork.sh'),
-          '',
-        );
+        fs.writeFileSync(path.join(tempHome, '.bash_aliases.ductwork.sh'), '');
+        fs.writeFileSync(path.join(tempHome, '.bash_aliases.termwork.sh'), '');
 
         // run commit with injected HOME
         const result = spawnSync(
@@ -2954,7 +2945,10 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 3, push: 'block' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
+        fs.writeFileSync(
+          path.join(tempDir, '.gitignore'),
+          '.meter/\n.agent/\n',
+        );
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup: add .gitignore'], {
           cwd: tempDir,
@@ -2975,14 +2969,8 @@ exit 1`,
         fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
 
         // create stub bash alias files to prevent warnings when HOME is fake
-        fs.writeFileSync(
-          path.join(tempHome, '.bash_aliases.ductwork.sh'),
-          '',
-        );
-        fs.writeFileSync(
-          path.join(tempHome, '.bash_aliases.termwork.sh'),
-          '',
-        );
+        fs.writeFileSync(path.join(tempHome, '.bash_aliases.ductwork.sh'), '');
+        fs.writeFileSync(path.join(tempHome, '.bash_aliases.termwork.sh'), '');
 
         // run commit with injected HOME (no global blocker)
         const result = spawnSync(
@@ -3056,7 +3044,10 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 5, push: 'allow' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
+        fs.writeFileSync(
+          path.join(tempDir, '.gitignore'),
+          '.meter/\n.agent/\n',
+        );
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup: add .gitignore'], {
           cwd: tempDir,
@@ -3077,14 +3068,8 @@ exit 1`,
         fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
 
         // create stub bash alias files to prevent warnings when HOME is fake
-        fs.writeFileSync(
-          path.join(tempHome, '.bash_aliases.ductwork.sh'),
-          '',
-        );
-        fs.writeFileSync(
-          path.join(tempHome, '.bash_aliases.termwork.sh'),
-          '',
-        );
+        fs.writeFileSync(path.join(tempHome, '.bash_aliases.ductwork.sh'), '');
+        fs.writeFileSync(path.join(tempHome, '.bash_aliases.termwork.sh'), '');
 
         // run commit with injected HOME (corrupt global blocker)
         const result = spawnSync(
@@ -3199,7 +3184,10 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 3, push: 'block' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
+        fs.writeFileSync(
+          path.join(tempDir, '.gitignore'),
+          '.meter/\n.agent/\n',
+        );
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup'], { cwd: tempDir });
         spawnSync('git', ['checkout', '-b', 'fix/test-branch'], {
@@ -3282,7 +3270,10 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 3, push: 'block' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
+        fs.writeFileSync(
+          path.join(tempDir, '.gitignore'),
+          '.meter/\n.agent/\n',
+        );
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup'], { cwd: tempDir });
         spawnSync('git', ['checkout', '-b', 'fix/test-branch'], {

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.set.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.set.integration.test.ts
@@ -50,15 +50,18 @@ describe('git.commit.set.sh', () => {
         JSON.stringify(args.meterState, null, 2),
       );
 
-      // commit .gitignore for .meter/ so it doesn't trigger the unstaged guard
+      // commit .gitignore for .meter/ and .agent/ so they don't trigger the unstaged guard
       const gitignorePath = path.join(tempDir, '.gitignore');
       const prior = fs.existsSync(gitignorePath)
         ? fs.readFileSync(gitignorePath, 'utf-8')
         : '';
-      if (!prior.includes('.meter/')) {
-        fs.writeFileSync(gitignorePath, `${prior}\n.meter/\n`);
+      if (!prior.includes('.meter/') || !prior.includes('.agent/')) {
+        const additions = [];
+        if (!prior.includes('.meter/')) additions.push('.meter/');
+        if (!prior.includes('.agent/')) additions.push('.agent/');
+        fs.writeFileSync(gitignorePath, `${prior}\n${additions.join('\n')}\n`);
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
-        spawnSync('git', ['commit', '-m', 'setup: add .gitignore for .meter'], {
+        spawnSync('git', ['commit', '-m', 'setup: add .gitignore'], {
           cwd: tempDir,
         });
       }
@@ -124,6 +127,33 @@ describe('git.commit.set.sh', () => {
 
     // always use isolated HOME to prevent global blocker from effects
     const isolatedHome = genTempDir({ slug: 'git-set-home', git: false });
+
+    // set up org permission so org blocker check passes
+    const orgMeterDir = path.join(
+      isolatedHome,
+      '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+    );
+    fs.mkdirSync(orgMeterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+      JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+    );
+
+    // set up .agent/keyrack.yml so org can be detected from repo
+    const agentDir = path.join(tempDir, '.agent');
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+    // create stub bash alias files to prevent warnings when HOME is fake
+    // (user's .bash_aliases sources these from $HOME, which breaks with fake HOME)
+    fs.writeFileSync(
+      path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+      '',
+    );
+    fs.writeFileSync(
+      path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+      '',
+    );
 
     const result = spawnSync('bash', [scriptPath, ...finalArgs], {
       cwd: tempDir,
@@ -641,6 +671,28 @@ exit 1`,
 
         // run in plan mode with push (with isolated HOME to avoid global blocker)
         const isolatedHome = genTempDir({ slug: 'plan-pr-home', git: false });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -750,6 +802,28 @@ exit 1`,
           slug: 'plan-pr-history-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -881,6 +955,28 @@ exit 1`,
           slug: 'stacked-branch-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -1345,6 +1441,28 @@ exit 1`,
           slug: 'autorevoke-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -1641,6 +1759,33 @@ exit 1`,
           slug: 'cont-first-fix-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files to prevent warnings when HOME is fake
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -1703,6 +1848,33 @@ exit 1`,
           slug: 'cont-first-feat-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files to prevent warnings when HOME is fake
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -1914,6 +2086,33 @@ exit 1`,
           slug: 'cont-prefix-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -1983,6 +2182,33 @@ exit 1`,
           slug: 'cont-scope-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -2052,6 +2278,33 @@ exit 1`,
           slug: 'cont-chore-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -2118,6 +2371,33 @@ exit 1`,
 
         // docs: should succeed (exempt)
         const isolatedHome = genTempDir({ slug: 'cont-docs-home', git: false });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -2189,6 +2469,36 @@ exit 1`,
             slug: 'chore-then-fix-home',
             git: false,
           });
+
+          // set up org permission in isolated HOME
+          const orgMeterDir = path.join(
+            isolatedHome,
+            '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+          );
+          fs.mkdirSync(orgMeterDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+            JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+          );
+
+          // set up .agent/keyrack.yml so org can be detected from repo
+          const agentDir = path.join(tempDir, '.agent');
+          fs.mkdirSync(agentDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(agentDir, 'keyrack.yml'),
+            'org: ehmpathy\n',
+          );
+
+          // create stub bash alias files
+          fs.writeFileSync(
+            path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+            '',
+          );
+          fs.writeFileSync(
+            path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+            '',
+          );
+
           const result = spawnSync(
             'bash',
             [
@@ -2252,6 +2562,33 @@ exit 1`,
           slug: 'cont-fresh-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -2321,6 +2658,33 @@ exit 1`,
           slug: 'chore-fresh-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -2391,6 +2755,33 @@ exit 1`,
           slug: 'noscope-fresh-home',
           git: false,
         });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [
@@ -2460,7 +2851,7 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 5, push: 'allow' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n');
+        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup: add .gitignore'], {
           cwd: tempDir,
@@ -2474,6 +2865,21 @@ exit 1`,
         // create and stage test file
         fs.writeFileSync(path.join(tempDir, 'fix.txt'), 'fixed content');
         spawnSync('git', ['add', 'fix.txt'], { cwd: tempDir });
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files to prevent warnings when HOME is fake
+        fs.writeFileSync(
+          path.join(tempHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(tempHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
 
         // run commit with injected HOME
         const result = spawnSync(
@@ -2520,6 +2926,17 @@ exit 1`,
           git: false,
         });
 
+        // set up org permission so org blocker check passes
+        const orgMeterDir = path.join(
+          tempHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
         // create temp git repo with local quota
         const tempDir = genTempDir({
           slug: 'git-commit-set-test',
@@ -2537,7 +2954,7 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 3, push: 'block' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n');
+        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup: add .gitignore'], {
           cwd: tempDir,
@@ -2551,6 +2968,21 @@ exit 1`,
         // create and stage test file
         fs.writeFileSync(path.join(tempDir, 'fix.txt'), 'fixed content');
         spawnSync('git', ['add', 'fix.txt'], { cwd: tempDir });
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files to prevent warnings when HOME is fake
+        fs.writeFileSync(
+          path.join(tempHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(tempHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
 
         // run commit with injected HOME (no global blocker)
         const result = spawnSync(
@@ -2624,7 +3056,7 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 5, push: 'allow' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n');
+        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup: add .gitignore'], {
           cwd: tempDir,
@@ -2638,6 +3070,21 @@ exit 1`,
         // create and stage test file
         fs.writeFileSync(path.join(tempDir, 'fix.txt'), 'fixed content');
         spawnSync('git', ['add', 'fix.txt'], { cwd: tempDir });
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files to prevent warnings when HOME is fake
+        fs.writeFileSync(
+          path.join(tempHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(tempHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
 
         // run commit with injected HOME (corrupt global blocker)
         const result = spawnSync(
@@ -2752,7 +3199,7 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 3, push: 'block' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n');
+        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup'], { cwd: tempDir });
         spawnSync('git', ['checkout', '-b', 'fix/test-branch'], {
@@ -2765,6 +3212,33 @@ exit 1`,
 
         // run with NODE_ENV=production to trigger failfast
         const isolatedHome = genTempDir({ slug: 'git-set-home', git: false });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [scriptPath, '-m', 'fix(api): test\n\n- change', '--mode', 'apply'],
@@ -2808,7 +3282,7 @@ exit 1`,
           path.join(meterDir, 'git.commit.uses.jsonc'),
           JSON.stringify({ uses: 3, push: 'block' }, null, 2),
         );
-        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n');
+        fs.writeFileSync(path.join(tempDir, '.gitignore'), '.meter/\n.agent/\n');
         spawnSync('git', ['add', '.gitignore'], { cwd: tempDir });
         spawnSync('git', ['commit', '-m', 'setup'], { cwd: tempDir });
         spawnSync('git', ['checkout', '-b', 'fix/test-branch'], {
@@ -2821,6 +3295,33 @@ exit 1`,
 
         // run with NODE_ENV=production to trigger failfast
         const isolatedHome = genTempDir({ slug: 'git-set-home', git: false });
+
+        // set up org permission in isolated HOME
+        const orgMeterDir = path.join(
+          isolatedHome,
+          '.rhachet/storage/repo=ehmpathy/role=mechanic/.meter',
+        );
+        fs.mkdirSync(orgMeterDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(orgMeterDir, 'git.commit.uses.org.jsonc'),
+          JSON.stringify({ orgs: { ehmpathy: 'allowed' } }, null, 2),
+        );
+
+        // set up .agent/keyrack.yml so org can be detected from repo
+        const agentDir = path.join(tempDir, '.agent');
+        fs.mkdirSync(agentDir, { recursive: true });
+        fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), 'org: ehmpathy\n');
+
+        // create stub bash alias files
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.ductwork.sh'),
+          '',
+        );
+        fs.writeFileSync(
+          path.join(isolatedHome, '.bash_aliases.termwork.sh'),
+          '',
+        );
+
         const result = spawnSync(
           'bash',
           [scriptPath, '-m', 'fix(api): test\n\n- change', '--mode', 'apply'],

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.set.sh
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.set.sh
@@ -433,6 +433,15 @@ if ! check_global_blocker; then
   exit 2
 fi
 
+# check org blocker (after global, before local)
+if ! check_org_blocker; then
+  print_turtle_header "bummer dude..."
+  print_tree_start "git.commit.set"
+  print_tree_error "$ORG_BLOCK_REASON"
+  print_instruction "ask your human to allow:" "  \$ git.commit.uses allow --org <org>"
+  exit 2
+fi
+
 # check state file exists
 if [[ ! -f "$STATE_FILE" ]]; then
   print_turtle_header "bummer dude..."

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.integration.test.ts
@@ -807,6 +807,350 @@ describe('git.commit.uses.sh', () => {
     });
   });
 
+  // ========================================
+  // org-level permission tests
+  // ========================================
+
+  /**
+   * .what = run command with org state file
+   * .why = tests org-level permission management
+   */
+  const runWithOrgStorage = (args: {
+    args: string[];
+    orgState?: Record<string, string>;
+  }): {
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+    tempDir: string;
+    tempHome: string;
+    orgStateFile: string;
+  } => {
+    const tempDir = genTempDir({ slug: 'git-commit-uses-org-test', git: true });
+    const tempHome = genTempDir({
+      slug: 'git-commit-uses-org-home',
+      git: false,
+    });
+    const globalMeterDir = path.join(
+      tempHome,
+      '.rhachet',
+      'storage',
+      'repo=ehmpathy',
+      'role=mechanic',
+      '.meter',
+    );
+    const orgStateFile = path.join(globalMeterDir, 'git.commit.uses.org.jsonc');
+
+    // create org state if provided
+    if (args.orgState) {
+      fs.mkdirSync(globalMeterDir, { recursive: true });
+      fs.writeFileSync(
+        orgStateFile,
+        JSON.stringify({ orgs: args.orgState }, null, 2),
+      );
+    }
+
+    const result = spawnSync('bash', [scriptPath, ...args.args], {
+      cwd: tempDir,
+      encoding: 'utf-8' as const,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, HOME: tempHome, __I_AM_HUMAN: 'true' },
+    });
+
+    return {
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      exitCode: result.status ?? 1,
+      tempDir,
+      tempHome,
+      orgStateFile,
+    };
+  };
+
+  given('[case22] allow --org ehmpathy', () => {
+    when('[t0] no org config', () => {
+      then('creates org state with ehmpathy allowed', () => {
+        const result = runWithOrgStorage({
+          args: ['allow', '--org', 'ehmpathy'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('shell yeah');
+        expect(result.stdout).toContain('ehmpathy: allowed');
+        expect(fs.existsSync(result.orgStateFile)).toBe(true);
+
+        const state = JSON.parse(fs.readFileSync(result.orgStateFile, 'utf-8'));
+        expect(state.orgs.ehmpathy).toBe('allowed');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] org was blocked', () => {
+      then('updates to allowed', () => {
+        const result = runWithOrgStorage({
+          args: ['allow', '--org', 'ehmpathy'],
+          orgState: { ehmpathy: 'blocked' },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('ehmpathy: allowed');
+
+        const state = JSON.parse(fs.readFileSync(result.orgStateFile, 'utf-8'));
+        expect(state.orgs.ehmpathy).toBe('allowed');
+      });
+    });
+  });
+
+  given('[case23] block --org ehmpathy', () => {
+    when('[t0] org was allowed', () => {
+      then('updates to blocked', () => {
+        const result = runWithOrgStorage({
+          args: ['block', '--org', 'ehmpathy'],
+          orgState: { ehmpathy: 'allowed' },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('groovy, bond fire time');
+        expect(result.stdout).toContain('ehmpathy: blocked');
+
+        const state = JSON.parse(fs.readFileSync(result.orgStateFile, 'utf-8'));
+        expect(state.orgs.ehmpathy).toBe('blocked');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case24] allow --org @all', () => {
+    when('[t0] orgs had mixed states', () => {
+      then('resets all and sets @all to allowed', () => {
+        const result = runWithOrgStorage({
+          args: ['allow', '--org', '@all'],
+          orgState: { ehmpathy: 'blocked', ahbode: 'allowed' },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('reset: all orgs');
+        expect(result.stdout).toContain('@all: allowed');
+
+        const state = JSON.parse(fs.readFileSync(result.orgStateFile, 'utf-8'));
+        expect(state.orgs).toEqual({ '@all': 'allowed' });
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case25] block --org @all', () => {
+    when('[t0] orgs had mixed states', () => {
+      then('resets all and sets @all to blocked', () => {
+        const result = runWithOrgStorage({
+          args: ['block', '--org', '@all'],
+          orgState: { ehmpathy: 'allowed', ahbode: 'blocked' },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('reset: all orgs');
+        expect(result.stdout).toContain('@all: blocked');
+
+        const state = JSON.parse(fs.readFileSync(result.orgStateFile, 'utf-8'));
+        expect(state.orgs).toEqual({ '@all': 'blocked' });
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case26] del --org ehmpathy', () => {
+    when('[t0] org has config', () => {
+      then('removes org config, defers to @all', () => {
+        const result = runWithOrgStorage({
+          args: ['del', '--org', 'ehmpathy'],
+          orgState: { '@all': 'blocked', ehmpathy: 'allowed' },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('righteous');
+        expect(result.stdout).toContain('ehmpathy: removed');
+        expect(result.stdout).toContain('inherits from @all');
+
+        const state = JSON.parse(fs.readFileSync(result.orgStateFile, 'utf-8'));
+        expect(state.orgs.ehmpathy).toBeUndefined();
+        expect(state.orgs['@all']).toBe('blocked');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] del --org @all', () => {
+      then('errors - cannot delete @all', () => {
+        const result = runWithOrgStorage({
+          args: ['del', '--org', '@all'],
+          orgState: { '@all': 'allowed' },
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('cannot delete @all');
+      });
+    });
+  });
+
+  given('[case27] get --org', () => {
+    when('[t0] orgs have config', () => {
+      then('shows all org configs', () => {
+        const result = runWithOrgStorage({
+          args: ['get', '--org'],
+          orgState: { '@all': 'blocked', ehmpathy: 'allowed' },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('lets check the meter');
+        expect(result.stdout).toContain('@all: blocked');
+        expect(result.stdout).toContain('ehmpathy: allowed');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] no org config', () => {
+      then('shows no org configs set', () => {
+        const result = runWithOrgStorage({
+          args: ['get', '--org'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('no org configs set');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case28] get --org ehmpathy', () => {
+    when('[t0] org has explicit config', () => {
+      then('shows org config', () => {
+        const result = runWithOrgStorage({
+          args: ['get', '--org', 'ehmpathy'],
+          orgState: { ehmpathy: 'allowed' },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('ehmpathy: allowed');
+      });
+    });
+
+    when('[t1] org unset but @all set', () => {
+      then('shows inherited from @all', () => {
+        const result = runWithOrgStorage({
+          args: ['get', '--org', 'ehmpathy'],
+          orgState: { '@all': 'blocked' },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('ehmpathy: blocked (from @all)');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case29] typo protection: all vs @all', () => {
+    when('[t0] user types "all" instead of "@all"', () => {
+      then('suggests @all', () => {
+        const result = runWithOrgStorage({
+          args: ['block', '--org', 'all'],
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('bummer dude');
+        expect(result.stdout).toContain('did you mean @all');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] user types "ALL" instead of "@all"', () => {
+      then('suggests @all', () => {
+        const result = runWithOrgStorage({
+          args: ['allow', '--org', 'ALL'],
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('did you mean @all');
+      });
+    });
+  });
+
+  given('[case30] TTY guard for org mutations', () => {
+    const runOrgWithoutTtyBypass = (args: {
+      args: string[];
+    }): {
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+    } => {
+      const tempDir = genTempDir({
+        slug: 'git-commit-uses-org-tty-test',
+        git: true,
+      });
+      const tempHome = genTempDir({
+        slug: 'git-commit-uses-org-tty-home',
+        git: false,
+      });
+
+      const result = spawnSync('bash', [scriptPath, ...args.args], {
+        cwd: tempDir,
+        encoding: 'utf-8' as const,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, HOME: tempHome },
+        // no __I_AM_HUMAN
+      });
+
+      return {
+        stdout: result.stdout ?? '',
+        stderr: result.stderr ?? '',
+        exitCode: result.status ?? 1,
+      };
+    };
+
+    when('[t0] allow --org is called from non-TTY', () => {
+      then('blocks with human-only error', () => {
+        const result = runOrgWithoutTtyBypass({
+          args: ['allow', '--org', 'ehmpathy'],
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('only humans can run this command');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] block --org is called from non-TTY', () => {
+      then('blocks with human-only error', () => {
+        const result = runOrgWithoutTtyBypass({
+          args: ['block', '--org', 'ehmpathy'],
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('only humans can run this command');
+      });
+    });
+
+    when('[t2] del --org is called from non-TTY', () => {
+      then('blocks with human-only error', () => {
+        const result = runOrgWithoutTtyBypass({
+          args: ['del', '--org', 'ehmpathy'],
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('only humans can run this command');
+      });
+    });
+
+    when('[t3] get --org is called from non-TTY', () => {
+      then('succeeds (get is not a mutation)', () => {
+        const result = runOrgWithoutTtyBypass({
+          args: ['get', '--org'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('no org configs set');
+      });
+    });
+  });
+
   given('[case21] TTY guard for global mutations', () => {
     const runGlobalWithoutTtyBypass = (args: {
       args: string[];

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.org.sh
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.org.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+######################################################################
+# .what = manage org-level git commit permissions for mechanics
+#
+# .why  = humans can allow/block commits per org:
+#         - specific org overrides @all default
+#         - @all resets all orgs and sets default
+#         - org config is overridden by local repo config
+#
+# usage:
+#   git.commit.uses --org ehmpathy allow   # allow commits for ehmpathy
+#   git.commit.uses --org ahbode block     # block commits for ahbode
+#   git.commit.uses --org @all allow       # allow all orgs (reset + default)
+#   git.commit.uses --org @all block       # block all orgs (reset + default)
+#   git.commit.uses --org ehmpathy del     # remove ehmpathy config, defer to @all
+#   git.commit.uses --org get              # show all org configs
+#   git.commit.uses --org ehmpathy get     # show config for specific org
+#
+# guarantee:
+#   - state stored at ~/.rhachet/storage/repo=ehmpathy/role=mechanic/.meter/
+#   - specific org config overrides @all
+#   - org config is overridden by local repo config
+######################################################################
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/output.sh"
+
+# ensure we're in a git repo
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+  echo "error: not in a git repository"
+  exit 2
+fi
+
+# org state path
+ROLE_REPO="ehmpathy"
+ROLE_SLUG="mechanic"
+GLOBAL_METER_DIR="$HOME/.rhachet/storage/repo=$ROLE_REPO/role=$ROLE_SLUG/.meter"
+ORG_STATE_FILE="$GLOBAL_METER_DIR/git.commit.uses.org.jsonc"
+
+# parse args
+ORG_NAME=""
+COMMAND=""
+
+# first positional arg could be org name or command
+if [[ $# -ge 1 && "$1" != --* ]]; then
+  # check if it's a command
+  case "$1" in
+    allow|block|del|get)
+      COMMAND="$1"
+      shift
+      ;;
+    *)
+      ORG_NAME="$1"
+      shift
+      ;;
+  esac
+fi
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    allow|block|del|get)
+      COMMAND="$1"
+      shift
+      ;;
+    --help|-h)
+      echo "usage: git.commit.uses --org <org> allow|block|del"
+      echo "       git.commit.uses --org @all allow|block"
+      echo "       git.commit.uses --org get"
+      echo "       git.commit.uses --org <org> get"
+      echo ""
+      echo "commands:"
+      echo "  allow        allow commits for this org"
+      echo "  block        block commits for this org"
+      echo "  del          remove org config, defer to @all"
+      echo "  get          show org config(s)"
+      echo ""
+      echo "special values:"
+      echo "  @all         sets default for all orgs (resets all + sets default)"
+      echo ""
+      echo "options:"
+      echo "  --help, -h   show this help"
+      exit 0
+      ;;
+    --repo|--role|--skill|--local|--global|--org)
+      # rhachet passthrough args - ignore
+      shift
+      # if next arg exists and is not a flag, skip it too
+      if [[ $# -gt 0 && "$1" != --* && "$1" != -* ]]; then
+        shift
+      fi
+      ;;
+    --)
+      shift
+      ;;
+    --*)
+      echo "error: unknown option: $1"
+      exit 2
+      ;;
+    *)
+      # positional arg - could be org name
+      if [[ -z "$ORG_NAME" ]]; then
+        ORG_NAME="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+# validate command
+if [[ -z "$COMMAND" ]]; then
+  echo "error: command required (allow, block, del, or get)"
+  echo "usage: git.commit.uses --org <org> allow|block|del|get"
+  exit 2
+fi
+
+# typo protection: all/ALL → suggest @all
+if [[ "$ORG_NAME" == "all" || "$ORG_NAME" == "ALL" ]]; then
+  print_turtle_header "bummer dude..."
+  print_tree_start "git.commit.uses $COMMAND --org $ORG_NAME"
+  echo "   └─ error: did you mean @all?"
+  exit 2
+fi
+
+######################################################################
+# guard: mutation commands require TTY (human only)
+# note: __I_AM_HUMAN=true allows integration tests to run mutations
+######################################################################
+case "$COMMAND" in
+  allow|block|del)
+    if [[ ! -t 0 && "${__I_AM_HUMAN:-}" != "true" ]]; then
+      print_turtle_header "bummer dude..."
+      print_tree_start "git.commit.uses $COMMAND --org $ORG_NAME"
+      print_tree_error "only humans can run this command"
+      exit 2
+    fi
+    ;;
+esac
+
+######################################################################
+# operations: read/write org state file
+######################################################################
+read_org_file() {
+  if [[ -f "$ORG_STATE_FILE" ]]; then
+    cat "$ORG_STATE_FILE"
+  else
+    echo '{ "orgs": {} }'
+  fi
+}
+
+write_org_file() {
+  local content="$1"
+  mkdir -p "$GLOBAL_METER_DIR"
+  echo "$content" > "$ORG_STATE_FILE"
+}
+
+######################################################################
+# commands
+######################################################################
+case "$COMMAND" in
+  allow)
+    if [[ -z "$ORG_NAME" ]]; then
+      echo "error: org name required for allow"
+      echo "usage: git.commit.uses --org <org> allow"
+      exit 2
+    fi
+
+    CURRENT=$(read_org_file)
+
+    if [[ "$ORG_NAME" == "@all" ]]; then
+      # @all: reset all orgs to allowed + set @all default
+      UPDATED=$(echo '{ "orgs": { "@all": "allowed" } }')
+      write_org_file "$UPDATED"
+
+      print_turtle_header "shell yeah, back in the water!"
+      print_tree_start "git.commit.uses allow --org @all"
+      echo "   ├─ reset: all orgs → allowed"
+      echo "   └─ @all: allowed"
+    else
+      # specific org: set to allowed
+      UPDATED=$(echo "$CURRENT" | jq ".orgs[\"$ORG_NAME\"] = \"allowed\"")
+      write_org_file "$UPDATED"
+
+      print_turtle_header "shell yeah, back in the water!"
+      print_tree_start "git.commit.uses allow --org $ORG_NAME"
+      echo "   └─ $ORG_NAME: allowed"
+    fi
+    ;;
+
+  block)
+    if [[ -z "$ORG_NAME" ]]; then
+      echo "error: org name required for block"
+      echo "usage: git.commit.uses --org <org> block"
+      exit 2
+    fi
+
+    CURRENT=$(read_org_file)
+
+    if [[ "$ORG_NAME" == "@all" ]]; then
+      # @all: reset all orgs to blocked + set @all default
+      UPDATED=$(echo '{ "orgs": { "@all": "blocked" } }')
+      write_org_file "$UPDATED"
+
+      print_turtle_header "groovy, bond fire time"
+      print_tree_start "git.commit.uses block --org @all"
+      echo "   ├─ reset: all orgs → blocked"
+      echo "   └─ @all: blocked"
+    else
+      # specific org: set to blocked
+      UPDATED=$(echo "$CURRENT" | jq ".orgs[\"$ORG_NAME\"] = \"blocked\"")
+      write_org_file "$UPDATED"
+
+      print_turtle_header "groovy, bond fire time"
+      print_tree_start "git.commit.uses block --org $ORG_NAME"
+      echo "   └─ $ORG_NAME: blocked"
+    fi
+    ;;
+
+  del)
+    if [[ -z "$ORG_NAME" ]]; then
+      echo "error: org name required for del"
+      echo "usage: git.commit.uses --org <org> del"
+      exit 2
+    fi
+
+    if [[ "$ORG_NAME" == "@all" ]]; then
+      echo "error: cannot delete @all, use allow or block instead"
+      exit 2
+    fi
+
+    CURRENT=$(read_org_file)
+    UPDATED=$(echo "$CURRENT" | jq "del(.orgs[\"$ORG_NAME\"])")
+    write_org_file "$UPDATED"
+
+    print_turtle_header "righteous!"
+    print_tree_start "git.commit.uses del --org $ORG_NAME"
+    echo "   └─ $ORG_NAME: removed (inherits from @all)"
+    ;;
+
+  get)
+    print_turtle_header "lets check the meter..."
+    print_tree_start "git.commit.uses get --org${ORG_NAME:+ $ORG_NAME}"
+
+    if [[ ! -f "$ORG_STATE_FILE" ]]; then
+      echo "   └─ no org configs set"
+      exit 0
+    fi
+
+    CURRENT=$(read_org_file)
+
+    if [[ -n "$ORG_NAME" ]]; then
+      # show specific org
+      ORG_STATE=$(echo "$CURRENT" | jq -r ".orgs[\"$ORG_NAME\"] // \"unset\"")
+      ALL_STATE=$(echo "$CURRENT" | jq -r ".orgs[\"@all\"] // \"unset\"")
+
+      if [[ "$ORG_STATE" != "unset" ]]; then
+        echo "   └─ $ORG_NAME: $ORG_STATE"
+      elif [[ "$ALL_STATE" != "unset" ]]; then
+        echo "   └─ $ORG_NAME: $ALL_STATE (from @all)"
+      else
+        echo "   └─ $ORG_NAME: unset"
+      fi
+    else
+      # show all orgs
+      ORGS=$(echo "$CURRENT" | jq -r '.orgs | to_entries | .[] | "\(.key): \(.value)"')
+      if [[ -z "$ORGS" ]]; then
+        echo "   └─ no org configs set"
+      else
+        # count orgs for proper tree formatting
+        ORG_COUNT=$(echo "$ORGS" | wc -l)
+        CURRENT_IDX=0
+        while IFS= read -r line; do
+          CURRENT_IDX=$((CURRENT_IDX + 1))
+          if [[ $CURRENT_IDX -eq $ORG_COUNT ]]; then
+            echo "   └─ $line"
+          else
+            echo "   ├─ $line"
+          fi
+        done <<< "$ORGS"
+      fi
+    fi
+    ;;
+
+  *)
+    echo "error: unknown command: $COMMAND"
+    echo "usage: git.commit.uses --org <org> allow|block|del|get"
+    exit 2
+    ;;
+esac

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.precedence.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.precedence.integration.test.ts
@@ -1,0 +1,382 @@
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { genTempDir, given, then, when } from 'test-fns';
+
+/**
+ * .what = exhaustive precedence matrix tests for git.commit.uses
+ * .why = verify that precedence order (global > org > local) is correctly enforced
+ *
+ * precedence order (highest to lowest):
+ *   1. global blocked = always blocked (overrides all)
+ *   2. org config = overrides local
+ *   3. local config = base level
+ *
+ * legend:
+ *   ✓ = allowed
+ *   ✗ = blocked
+ *   ∅ = unset
+ *
+ * for each combination, we test whether git.commit.push can proceed.
+ */
+describe('git.commit.uses precedence matrix', () => {
+  const pushScriptPath = path.join(__dirname, 'git.commit.push.sh');
+
+  /**
+   * .what = run git.commit.push with full global/org/local setup
+   * .why = test actual precedence behavior via push command
+   */
+  const runPushWithPrecedence = (args: {
+    globalState?: 'blocked' | 'allowed';
+    orgState?: { org: string; state: 'blocked' | 'allowed' } | '@all-blocked' | '@all-allowed';
+    localState?: { uses: number; push: 'allow' | 'block' };
+    keyrackOrg: string;
+  }): {
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+    tempDir: string;
+    tempHome: string;
+  } => {
+    const tempDir = genTempDir({ slug: 'precedence-test', git: true });
+    const tempHome = genTempDir({ slug: 'precedence-home', git: false });
+
+    // create .agent/keyrack.yml with org
+    const agentDir = path.join(tempDir, '.agent');
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), `org: ${args.keyrackOrg}\n`);
+
+    // create global state if provided
+    const globalMeterDir = path.join(
+      tempHome,
+      '.rhachet',
+      'storage',
+      'repo=ehmpathy',
+      'role=mechanic',
+      '.meter',
+    );
+    if (args.globalState) {
+      fs.mkdirSync(globalMeterDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(globalMeterDir, 'git.commit.uses.jsonc'),
+        JSON.stringify({ blocked: args.globalState === 'blocked' }, null, 2),
+      );
+    }
+
+    // create org state if provided
+    if (args.orgState) {
+      fs.mkdirSync(globalMeterDir, { recursive: true });
+      let orgsObj: Record<string, string> = {};
+      if (args.orgState === '@all-blocked') {
+        orgsObj = { '@all': 'blocked' };
+      } else if (args.orgState === '@all-allowed') {
+        orgsObj = { '@all': 'allowed' };
+      } else {
+        orgsObj = { [args.orgState.org]: args.orgState.state };
+      }
+      fs.writeFileSync(
+        path.join(globalMeterDir, 'git.commit.uses.org.jsonc'),
+        JSON.stringify({ orgs: orgsObj }, null, 2),
+      );
+    }
+
+    // create local state if provided
+    if (args.localState) {
+      const meterDir = path.join(tempDir, '.meter');
+      fs.mkdirSync(meterDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(meterDir, 'git.commit.uses.jsonc'),
+        JSON.stringify(args.localState, null, 2),
+      );
+    }
+
+    // create branch and commit for push to work
+    spawnSync('git', ['checkout', '-b', 'turtle/feature'], { cwd: tempDir });
+    fs.writeFileSync(path.join(tempDir, 'file.txt'), 'content');
+    spawnSync('git', ['add', 'file.txt'], { cwd: tempDir });
+    spawnSync('git', [
+      '-c', 'user.name=seaturtle[bot]',
+      '-c', 'user.email=seaturtle@ehmpath.com',
+      'commit', '-m', 'feat: test commit',
+    ], { cwd: tempDir });
+
+    const result = spawnSync('bash', [pushScriptPath, '--mode', 'plan'], {
+      cwd: tempDir,
+      encoding: 'utf-8' as const,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        HOME: tempHome,
+      },
+    });
+
+    return {
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      exitCode: result.status ?? 1,
+      tempDir,
+      tempHome,
+    };
+  };
+
+  /**
+   * .what = helper to determine expected behavior
+   * .why = documents precedence rules in code
+   */
+  const getExpectedBehavior = (args: {
+    global: 'blocked' | 'allowed' | 'unset';
+    org: 'blocked' | 'allowed' | 'unset';
+    local: 'allowed' | 'blocked' | 'unset';
+  }): 'blocked' | 'allowed' => {
+    // rule 1: global blocked overrides all
+    if (args.global === 'blocked') return 'blocked';
+
+    // rule 2: org config is checked next
+    if (args.org === 'blocked') return 'blocked';
+    if (args.org === 'allowed') {
+      // org allowed, check local
+      if (args.local === 'blocked' || args.local === 'unset') return 'blocked';
+      return 'allowed';
+    }
+
+    // rule 3: org unset, check local
+    // note: with org unset, push is blocked due to no org config
+    if (args.org === 'unset') return 'blocked';
+
+    // fallback
+    return 'blocked';
+  };
+
+  // ================================================================
+  // GLOBAL BLOCKED cases - should ALWAYS block regardless of org/local
+  // ================================================================
+
+  given('[global=blocked, org=allowed, local=allowed]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked by global', () => {
+        const result = runPushWithPrecedence({
+          globalState: 'blocked',
+          orgState: { org: 'ehmpathy', state: 'allowed' },
+          localState: { uses: 3, push: 'allow' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('commits blocked globally');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[global=blocked, org=allowed, local=blocked]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked by global', () => {
+        const result = runPushWithPrecedence({
+          globalState: 'blocked',
+          orgState: { org: 'ehmpathy', state: 'allowed' },
+          localState: { uses: 3, push: 'block' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('commits blocked globally');
+      });
+    });
+  });
+
+  given('[global=blocked, org=allowed, local=unset]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked by global', () => {
+        const result = runPushWithPrecedence({
+          globalState: 'blocked',
+          orgState: { org: 'ehmpathy', state: 'allowed' },
+          localState: undefined,
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('commits blocked globally');
+      });
+    });
+  });
+
+  given('[global=blocked, org=blocked, local=allowed]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked by global (not by org)', () => {
+        const result = runPushWithPrecedence({
+          globalState: 'blocked',
+          orgState: { org: 'ehmpathy', state: 'blocked' },
+          localState: { uses: 3, push: 'allow' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('commits blocked globally');
+      });
+    });
+  });
+
+  given('[global=blocked, org=unset, local=allowed]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked by global', () => {
+        const result = runPushWithPrecedence({
+          globalState: 'blocked',
+          orgState: undefined,
+          localState: { uses: 3, push: 'allow' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('commits blocked globally');
+      });
+    });
+  });
+
+  // ================================================================
+  // ORG BLOCKED cases - should block when global is not blocked
+  // ================================================================
+
+  given('[global=unset, org=blocked, local=allowed]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked by org', () => {
+        const result = runPushWithPrecedence({
+          globalState: undefined,
+          orgState: { org: 'ehmpathy', state: 'blocked' },
+          localState: { uses: 3, push: 'allow' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('commits blocked for org ehmpathy');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[global=unset, org=@all-blocked, local=allowed]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked by @all default', () => {
+        const result = runPushWithPrecedence({
+          globalState: undefined,
+          orgState: '@all-blocked',
+          localState: { uses: 3, push: 'allow' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('commits blocked for org ehmpathy');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  // ================================================================
+  // ORG ALLOWED + LOCAL variations
+  // ================================================================
+
+  given('[global=unset, org=allowed, local=allowed]', () => {
+    when('[t0] push is attempted', () => {
+      then('allowed - shows plan', () => {
+        const result = runPushWithPrecedence({
+          globalState: undefined,
+          orgState: { org: 'ehmpathy', state: 'allowed' },
+          localState: { uses: 3, push: 'allow' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('heres the wave');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[global=unset, org=allowed, local=blocked]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked by local push config', () => {
+        const result = runPushWithPrecedence({
+          globalState: undefined,
+          orgState: { org: 'ehmpathy', state: 'allowed' },
+          localState: { uses: 3, push: 'block' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('push not allowed');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[global=unset, org=allowed, local=unset]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked - no local quota', () => {
+        const result = runPushWithPrecedence({
+          globalState: undefined,
+          orgState: { org: 'ehmpathy', state: 'allowed' },
+          localState: undefined,
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('push not allowed');
+      });
+    });
+  });
+
+  given('[global=unset, org=@all-allowed, local=allowed]', () => {
+    when('[t0] push is attempted', () => {
+      then('allowed via @all default', () => {
+        const result = runPushWithPrecedence({
+          globalState: undefined,
+          orgState: '@all-allowed',
+          localState: { uses: 3, push: 'allow' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('heres the wave');
+      });
+    });
+  });
+
+  // ================================================================
+  // ORG UNSET cases - should block due to absent org config
+  // ================================================================
+
+  given('[global=unset, org=unset, local=allowed]', () => {
+    when('[t0] push is attempted', () => {
+      then('blocked - org config required', () => {
+        const result = runPushWithPrecedence({
+          globalState: undefined,
+          orgState: undefined,
+          localState: { uses: 3, push: 'allow' },
+          keyrackOrg: 'ehmpathy',
+        });
+
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).toContain('org permissions not configured');
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  // ================================================================
+  // SUMMARY MATRIX
+  // ================================================================
+  // | global  | org      | local    | result  | reason                      |
+  // |---------|----------|----------|---------|-----------------------------|
+  // | blocked | allowed  | allowed  | blocked | global overrides            |
+  // | blocked | allowed  | blocked  | blocked | global overrides            |
+  // | blocked | allowed  | unset    | blocked | global overrides            |
+  // | blocked | blocked  | allowed  | blocked | global overrides            |
+  // | blocked | unset    | allowed  | blocked | global overrides            |
+  // | unset   | blocked  | allowed  | blocked | org blocks                  |
+  // | unset   | @all-blk | allowed  | blocked | @all default blocks         |
+  // | unset   | allowed  | allowed  | allowed | all levels allow            |
+  // | unset   | allowed  | blocked  | blocked | local push blocked          |
+  // | unset   | allowed  | unset    | blocked | no local quota              |
+  // | unset   | @all-alw | allowed  | allowed | @all default + local allow  |
+  // | unset   | unset    | allowed  | blocked | no org config               |
+  // ================================================================
+});

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.precedence.integration.test.ts
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.precedence.integration.test.ts
@@ -28,7 +28,10 @@ describe('git.commit.uses precedence matrix', () => {
    */
   const runPushWithPrecedence = (args: {
     globalState?: 'blocked' | 'allowed';
-    orgState?: { org: string; state: 'blocked' | 'allowed' } | '@all-blocked' | '@all-allowed';
+    orgState?:
+      | { org: string; state: 'blocked' | 'allowed' }
+      | '@all-blocked'
+      | '@all-allowed';
     localState?: { uses: number; push: 'allow' | 'block' };
     keyrackOrg: string;
   }): {
@@ -44,7 +47,10 @@ describe('git.commit.uses precedence matrix', () => {
     // create .agent/keyrack.yml with org
     const agentDir = path.join(tempDir, '.agent');
     fs.mkdirSync(agentDir, { recursive: true });
-    fs.writeFileSync(path.join(agentDir, 'keyrack.yml'), `org: ${args.keyrackOrg}\n`);
+    fs.writeFileSync(
+      path.join(agentDir, 'keyrack.yml'),
+      `org: ${args.keyrackOrg}\n`,
+    );
 
     // create global state if provided
     const globalMeterDir = path.join(
@@ -94,11 +100,19 @@ describe('git.commit.uses precedence matrix', () => {
     spawnSync('git', ['checkout', '-b', 'turtle/feature'], { cwd: tempDir });
     fs.writeFileSync(path.join(tempDir, 'file.txt'), 'content');
     spawnSync('git', ['add', 'file.txt'], { cwd: tempDir });
-    spawnSync('git', [
-      '-c', 'user.name=seaturtle[bot]',
-      '-c', 'user.email=seaturtle@ehmpath.com',
-      'commit', '-m', 'feat: test commit',
-    ], { cwd: tempDir });
+    spawnSync(
+      'git',
+      [
+        '-c',
+        'user.name=seaturtle[bot]',
+        '-c',
+        'user.email=seaturtle@ehmpath.com',
+        'commit',
+        '-m',
+        'feat: test commit',
+      ],
+      { cwd: tempDir },
+    );
 
     const result = spawnSync('bash', [pushScriptPath, '--mode', 'plan'], {
       cwd: tempDir,

--- a/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.sh
+++ b/src/domain.roles/mechanic/skills/git.commit/git.commit.uses.sh
@@ -16,6 +16,9 @@
 #   git.commit.uses block --global              # block commits globally
 #   git.commit.uses allow --global              # lift global blocker
 #   git.commit.uses get --global                # check global state
+#   git.commit.uses allow --org ehmpathy        # allow commits for ehmpathy org
+#   git.commit.uses block --org @all            # block commits for all orgs by default
+#   git.commit.uses get --org                   # show all org configs
 #
 # guarantee:
 #   - --push is required on set (except --quant 0 which defaults to block)
@@ -26,21 +29,27 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# check for --global flag
+# check for --global and --org flags
 GLOBAL_MODE=false
+ORG_MODE=false
 ARGS=()
 
 for arg in "$@"; do
   if [[ "$arg" == "--global" ]]; then
     GLOBAL_MODE=true
+  elif [[ "$arg" == "--org" ]]; then
+    ORG_MODE=true
   else
     ARGS+=("$arg")
   fi
 done
 
 # dispatch to appropriate handler
+# precedence: --global > --org > local
 if [[ "$GLOBAL_MODE" == "true" ]]; then
   exec "$SCRIPT_DIR/git.commit.uses.global.sh" "${ARGS[@]}"
+elif [[ "$ORG_MODE" == "true" ]]; then
+  exec "$SCRIPT_DIR/git.commit.uses.org.sh" "${ARGS[@]}"
 else
   exec "$SCRIPT_DIR/git.commit.uses.local.sh" "${ARGS[@]}"
 fi


### PR DESCRIPTION
feat(git.commit.uses): add org-level granularity for commit permissions

- add org-level config with precedence: global > org > local
- support @all as default for unconfigured orgs
- add exhaustive precedence matrix integration tests with snapshots
- add coconut hint for keyrack.yml not found error
- verify all 12 precedence combinations work correctly

---
🐢🌊 surfed in by seaturtle[bot]