### PR TITLE
fix(repo): gitignore .cache to prevent scratch and secret artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.local.json
 *.log
 .agent/.cache/
+.cache/
 bin/
 *.tsbuildinfo
 .artifact


### PR DESCRIPTION
fix(repo): gitignore .cache to prevent scratch and secret artifacts

- add .cache/ to .gitignore
- .cache/ is a scratch dir and must never be tracked
- prevents recurrence of the committed FIREWORKS_API_KEY incident

---
🐢🌊 surfed in by seaturtle[bot]