### PR TITLE
fix(cicd): pin npm@11 in publish, not npm@latest

### DIFF
--- a/.github/workflows/.publish-npm.yml
+++ b/.github/workflows/.publish-npm.yml
@@ -49,7 +49,9 @@ jobs:
           MIN_VERSION="11.5.1"
           if [ "$(printf '%s\n' "$MIN_VERSION" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
             echo "npm $NPM_VERSION < $MIN_VERSION, will upgrade npm now to support oidc..."
-            npm install -g npm@latest
+            # pin to npm@11: satisfies the oidc MIN_VERSION (11.5.1) and stays compatible
+            # with the node pin in .nvmrc. npm@latest (12.x) requires node >=22.22.2.
+            npm install -g npm@11
           else
             echo "npm $NPM_VERSION >= $MIN_VERSION, ready to use!"
           fi


### PR DESCRIPTION
fix(cicd): pin npm@11 in publish, not npm@latest

- npm@latest rolled to 12.0.1, which requires node >=22.22.2
- .nvmrc pins node 22.21.0, so the global npm upgrade aborted EBADENGINE
- npm@11 satisfies the oidc MIN_VERSION (11.5.1) and stays node-compatible
- unblocks the publish step that failed on the v1.38.2 release

---
🐢🌊 surfed in by seaturtle[bot]