### PR TITLE
fix(briefs): add iso-time/iso-price glossary rules

### DIFF
--- a/src/domain.roles/mechanic/boot.yml
+++ b/src/domain.roles/mechanic/boot.yml
@@ -148,6 +148,12 @@ subject.code.prod:
       # artifacts
       - briefs/practices/code.prod/consistent.artifacts/rule.require.pinned-versions.md
 
+      # glossaries — the adopted ubiqlang glossaries for domain primitives
+      - briefs/practices/code.prod/consistent.glossaries/rule.require.iso-time.md
+      - briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-time.md
+      - briefs/practices/code.prod/consistent.glossaries/rule.require.iso-price.md
+      - briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-price.md
+
     ref:
       # procedure supplements
       - briefs/practices/code.prod/evolvable.procedures/rule.require.input-context-pattern.md.pt2.md

--- a/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/.readme.md
+++ b/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/.readme.md
@@ -1,0 +1,39 @@
+# consistent.glossaries
+
+## .what
+
+rules that require the **adopted ubiqlang glossaries** for common domain primitives — the
+canonical packages we speak instead of raw language primitives.
+
+each glossary is a shared vocabulary for one primitive kind: a small set of types +
+`as*`/`is*` casts that give the primitive one unambiguous, safe representation everywhere
+in the codebase.
+
+## .the adopted glossaries
+
+| primitive | glossary | canonical type |
+|-----------|----------|----------------|
+| time / date / duration | `iso-time` | `IsoTimeStamp`, `IsoDateStamp`, `IsoDuration`, … |
+| money / price | `iso-price` | `IsoPriceWords` (e.g. `'USD 50.37'`) |
+
+## .why a glossary, not a raw primitive
+
+we adopt these packages for two reasons, together:
+
+- **ergonomics** — one obvious way to declare, cast, and compose the value; the common case
+  is a one-liner, the names read as a human expects
+- **safety** — the representation is unambiguous and the arithmetic is correct by
+  construction (no `0.1 + 0.2` float drift, no `'06/15/2024'`-vs-`'15/06/2024'` ambiguity)
+
+a raw `number` or `Date` is a map drawn by whatever code touched it last; the glossary type
+is the territory — one canonical, validated shape the whole codebase shares.
+
+## .the rules
+
+- `rule.require.iso-time` / `rule.forbid.any-time`
+- `rule.require.iso-price` / `rule.forbid.any-price`
+
+## .see also
+
+- `rule.require.ubiqlang` — one canonical word per concept (glossaries apply it to primitives)
+- `rule.require.read-package-docs-before-use` — read the glossary's readme before you reach for a primitive

--- a/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-price.md
+++ b/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-price.md
@@ -1,0 +1,130 @@
+# rule.forbid.any-price
+
+## .what
+
+do not represent a money or price value with an **any-price** shape — a bare `number` of
+dollars or cents, a display string like `'$50.37'`, or an ad-hoc `{ amount, currency }` bag —
+when that value is the declared, stored, or passed shape.
+
+**any-price** = any representation *other than* the canonical `iso-price` glossary. it is the
+loose, unconstrained twin of `IsoPriceWords` (`rule.require.iso-price`) — the same sense
+`any` carries in typescript: it could be any shape at all, so the compiler guards no
+currency, no unit, no precision.
+
+above all: do not do money arithmetic on an any-price number. `0.1 + 0.2` is
+`0.30000000000000004`, and that cent reaches a real invoice.
+
+## .why
+
+`iso-price` is the adopted glossary for **ergonomics** and **safety**; an any-price shape
+forfeits both:
+
+- **float drift** — ieee-754 cannot hold `0.30` exactly. every `+`, `*`, `/` on money
+  numbers accrues error; the glossary's bigint arithmetic cannot.
+- **lost currency** — a bare `number` drops the currency, so `usd + eur` silently sums to a
+  meaningless total. `IsoPriceWords` carries the currency and refuses the mismatch.
+- **hidden unit** — is `5037` dollars or cents? an any-price number never says.
+  `'USD 50.37'` does.
+- **sprawl** — every ad-hoc `{ amount, currency }` bag is a private map; the glossary is one
+  shared, validated, serializable territory.
+
+## .the forbidden shapes
+
+| forbidden (any-price) | why | use instead (iso-price) |
+|-----------------------|-----|-------------------------|
+| `pricePerDay: number` | unit + currency hidden | `IsoPriceWords` |
+| `total: number` (cents) | unit hidden, float-prone | `IsoPriceWords` |
+| `price: '$50.37'` (display string) | locale-bound, not canonical | `IsoPriceWords` (`'USD 50.37'`) |
+| `{ amount: number; currency: string }` bag | reinvents `IsoPriceShape`, no validation | `IsoPriceWords` / `IsoPriceShape` |
+| `a + b`, `qty * price` on money numbers | float drift, cross-currency add | `priceSum`, `priceMultiply` |
+
+## .the one allowed use of an any-price value
+
+a bare `number` / display string / `{ amount, currency }` is allowed **only** as transient
+input to `asIsoPrice` at a boundary — the instant a price enters from an sdk or a form. it is
+cast to `IsoPriceWords` at once and never stored or passed as any-price.
+
+```ts
+import { asIsoPrice } from 'iso-price';
+
+// ✅ the sdk cents live only long enough to be cast at the boundary
+const paid = asIsoPrice({ amount: sdkCharge.amount, currency: sdkCharge.currency });
+```
+
+## .reach for instead
+
+the `iso-price` operations that replace each any-price habit — use the **`price*`
+(noun-first)** form so every price op groups under one autocomplete prefix:
+
+| any-price habit | reach for |
+|-----------------|-----------|
+| `parseFloat('$50.37')` | `asIsoPrice` |
+| `a + b` on money | `priceSum(a, b)` |
+| `a - b` on money | `priceSub(a, b)` |
+| `price * qty` | `priceMultiply({ of: price, by: qty })` |
+| `total / n` | `priceDivide({ of: total, by: n })` |
+| split a bill by hand | `priceAllocate({ of, into, remainder })` |
+| `a === b` on money | `isIsoPrice.equal(a, b)` |
+| `a > b` on money | `isIsoPrice.greater(a, b)` |
+| `n.toFixed(2)` for display | `asIsoPriceHuman` |
+
+> read the full glossary:
+> `rhx git.repo.get lines --in ehmpathy/iso-price --paths 'readme.md'`
+
+## .caveats
+
+- **the boundary cast is the escape hatch, not a loophole** — a raw `number` may enter and be
+  cast at once; it may not linger as a field, a return, or a passed value.
+- **never `===` two prices** — `'USD 0.25'` and `'USD 0.250_000'` are equal in value but not
+  as strings; compare with `isIsoPrice.equal`.
+- **display is not storage** — `asIsoPriceHuman` (`'$50.37'`) is a locale-bound, lossy view;
+  it belongs at the ui edge, never as a stored or passed value.
+- **a scalar multiplier stays a `number`** — `priceMultiply({ of: price, by: 7 })` is
+  correct; `by` is a plain quantity, not a price.
+
+## .examples
+
+both demonstrate the same computation — a quote total, `rate × hours` — done wrong, then
+right.
+
+### 👎 bad — any-price number, raw multiply
+
+```ts
+interface SurfLessonQuote {
+  hourlyRate: number;       // '$'? cents? which currency?
+  hours: number;
+}
+
+// raw multiply — float drift + no currency guard
+const total = quote.hourlyRate * quote.hours;
+```
+
+### 👍 good — iso-price words, `priceMultiply`
+
+```ts
+import type { IsoPriceWords } from 'iso-price';
+import { priceMultiply } from 'iso-price';
+
+interface SurfLessonQuote {
+  hourlyRate: IsoPriceWords;              // 'USD 80.00'
+  hours: number;                          // scalar quantity — the multiplier
+}
+
+// same rate × hours, now lossless + currency-safe
+const total = priceMultiply({ of: quote.hourlyRate, by: quote.hours }); // 'USD 240.00'
+```
+
+## .enforcement
+
+- a money / price / fee / total declared as `number` or display string in a domain object,
+  contract, or stored value = **blocker**
+- an ad-hoc `{ amount, currency }` bag as the stored or passed representation = **blocker**
+- raw `+` / `*` / `/` arithmetic on money numbers = **blocker**
+- an any-price value is a **false positive** only when it is transient input to `asIsoPrice`
+  at a boundary
+
+## .see also
+
+- `rule.require.iso-price` — the positive pair (what to use)
+- `.readme` (consistent.glossaries) — why the glossary family exists
+- `rule.forbid.io-as-domain-objects` — the adjacent rule against ad-hoc contract bags

--- a/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-price.md.min
+++ b/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-price.md.min
@@ -1,0 +1,69 @@
+# rule.forbid.any-price
+
+## .what
+do not represent money/price with an ANY-PRICE shape — bare number (dollars or cents), display string '$50.37', or ad-hoc { amount, currency } bag — as the declared/stored/passed shape
+any-price = any representation OTHER THAN the canonical iso-price glossary. the loose, unconstrained twin of IsoPriceWords (rule.require.iso-price) — same sense `any` carries in typescript: could be any shape at all, compiler guards no currency/unit/precision
+above all: no money arithmetic on an any-price number. 0.1 + 0.2 = 0.30000000000000004, and that cent reaches a real invoice
+
+## .why
+iso-price = adopted glossary for ergonomics + safety; an any-price shape forfeits both:
+- float drift — ieee-754 cannot hold 0.30 exactly; every +,*,/ on money numbers accrues error. bigint arithmetic cannot
+- lost currency — a bare number drops the currency, so usd + eur sums to a meaningless total. IsoPriceWords carries the currency and refuses the mismatch
+- hidden unit — is 5037 dollars or cents? an any-price number never says; 'USD 50.37' does
+- sprawl — every ad-hoc { amount, currency } bag is a private map; the glossary is one validated territory
+
+## .the forbidden shapes
+- `pricePerDay: number` → IsoPriceWords
+- `total: number` (cents) → IsoPriceWords
+- `price: '$50.37'` display string → IsoPriceWords ('USD 50.37')
+- `{ amount: number; currency: string }` bag → IsoPriceWords/IsoPriceShape
+- `a + b`, `qty * price` on money numbers → priceSum, priceMultiply
+
+## .the one allowed use
+bare number/display string/{ amount, currency } allowed ONLY as transient input to asIsoPrice at a boundary (sdk/form); cast to IsoPriceWords at once, never stored/passed as any-price
+```ts
+const paid = asIsoPrice({ amount: sdkCharge.amount, currency: sdkCharge.currency });
+```
+
+## .reach for instead
+use the price* (noun-first) form so every price op groups under one autocomplete prefix:
+- `parseFloat('$50.37')` → asIsoPrice
+- `a + b` on money → priceSum(a, b)
+- `a - b` on money → priceSub(a, b)
+- `price * qty` → priceMultiply({ of: price, by: qty })
+- `total / n` → priceDivide({ of: total, by: n })
+- split a bill by hand → priceAllocate({ of, into, remainder })
+- `a === b` on money → isIsoPrice.equal(a, b); `a > b` → isIsoPrice.greater(a, b)
+- `n.toFixed(2)` for display → asIsoPriceHuman
+> read the full glossary: rhx git.repo.get lines --in ehmpathy/iso-price --paths 'readme.md'
+
+## .caveats
+- the boundary cast is the escape hatch, not a loophole — a raw number may enter and be cast at once; it may not linger as a field/return/passed value
+- never === two prices — 'USD 0.25' equals 'USD 0.250_000' in value, not as strings; compare with isIsoPrice.equal
+- display is not storage — asIsoPriceHuman ('$50.37') is a locale-bound lossy view; keep at the ui edge, never stored/passed
+- a scalar multiplier stays a number — priceMultiply({ of: price, by: 7 }); `by` is a plain quantity, not a price
+
+## .examples
+both demonstrate the same computation — a quote total, rate × hours — done wrong, then right
+👎 bad
+```ts
+interface SurfLessonQuote { hourlyRate: number; hours: number; }
+const total = quote.hourlyRate * quote.hours; // raw multiply — float drift + no currency guard
+```
+👍 good
+```ts
+import type { IsoPriceWords } from 'iso-price';
+import { priceMultiply } from 'iso-price';
+interface SurfLessonQuote { hourlyRate: IsoPriceWords; hours: number; }
+const total = priceMultiply({ of: quote.hourlyRate, by: quote.hours }); // 'USD 240.00'
+```
+
+## .enforcement
+- money/price/fee/total declared as number or display string in a domain object, contract, or stored value = blocker
+- ad-hoc { amount, currency } bag as the stored/passed representation = blocker
+- raw +/*/ arithmetic on money numbers = blocker
+- any-price value is a false positive only as transient input to asIsoPrice at a boundary
+
+## .see also
+- rule.require.iso-price — the positive pair
+- rule.forbid.io-as-domain-objects — the adjacent rule against ad-hoc contract bags

--- a/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-time.md
+++ b/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-time.md
@@ -1,0 +1,119 @@
+# rule.forbid.any-time
+
+## .what
+
+do not represent a time, date, or duration value with an **any-time** shape — a bare `Date`,
+a `number` epoch, an ad-hoc time string, a `moment`/`dayjs` object, or a hand-rolled
+`{ hours; mins }` bag — when that value is the declared, stored, or passed shape.
+
+**any-time** = any representation *other than* the canonical `iso-time` glossary. it is the
+loose, unconstrained twin of the strict `iso-time` type (`rule.require.iso-time`) — the same
+sense `any` carries in typescript: it could be anything, so the compiler guarantees no shape
+at all.
+
+## .why
+
+`iso-time` is the adopted glossary for **ergonomics** and **safety**; an any-time shape
+forfeits both:
+
+- **ambiguity** — a `Date` carries an implicit zone; a `'06/15/2024'` string reads as june
+  or as the 6th per the reader's locale; a bare `number` hides its unit (seconds? ms?).
+  each forces a re-read, and a wrong read is a wrong time.
+- **drift** — an any-time duration invites hand-rolled millisecond math, where an off-by-1000
+  hides for months. the glossary's `addDuration` / `getDuration` cannot drift.
+- **sprawl** — every any-time shape is a private map; ten files grow ten slightly-different
+  time shapes. the glossary is one shared territory.
+
+## .the forbidden shapes
+
+| forbidden (any-time) | why | use instead (iso-time) |
+|----------------------|-----|------------------------|
+| `bookedAt: Date` | implicit zone, ambiguous on the wire | `IsoTimeStamp` |
+| `startsAt: string` | format unknowable (`'06/15'`?) | `IsoDateStamp` / `IsoTimeFloat` |
+| `expiresAt: number` | unit hidden (s? ms?) | `IsoTimeStamp` |
+| `duration: number` | unit hidden | `IsoDuration` |
+| `{ hrs, mins }` ad-hoc bag | reinvents the glossary | `IsoDurationShape` |
+| `moment()` / `dayjs()` object | heavyweight, mutable, non-serializable | `iso-time` cast |
+| `Date.now() + 3600_000` | hand-rolled ms math, drift-prone | `addDuration(now(), { hours: 1 })` |
+
+## .the one allowed use of an any-time value
+
+a bare `Date` or `number` is allowed **only** as transient input to an `as*` cast at a
+boundary — the instant a time enters from the clock or an sdk. it is cast to an `iso-time`
+type at once and never stored or passed as any-time.
+
+```ts
+import { asIsoTimeStamp } from 'iso-time';
+
+// ✅ the Date lives only long enough to be cast at the boundary
+const paddledOutAt = asIsoTimeStamp(sdkSession.startedAt); // Date -> IsoTimeStamp
+```
+
+## .reach for instead
+
+the `iso-time` operations that replace each any-time habit:
+
+| any-time habit | reach for |
+|----------------|-----------|
+| `new Date(x)` to parse | `asIsoTimeStamp` / `asIsoDateStamp` |
+| `Date.now()` / `new Date()` | `now()` / `today()` |
+| `a.getTime() + ms` | `addDuration(a, dur)` |
+| `a.getTime() - ms` | `subDuration(a, dur)` |
+| `b.getTime() - a.getTime()` | `getDuration({ of: { range: { since: a, until: b } } })` |
+| `ms1 + ms2` | `sumDurations(dur1, dur2)` |
+| a hand-rolled `isValidDate` | `isIsoTimeStamp` / `isIsoDateStamp` |
+
+> read the full glossary:
+> `rhx git.repo.get lines --in ehmpathy/iso-time --paths 'readme.md'`
+
+## .caveats
+
+- **the boundary cast is the escape hatch, not a loophole** — a `Date` may enter and be cast
+  at once; it may not linger as a field, a return, or a passed value.
+- **`toMilliseconds(dur)` is the sanctioned way to hand a duration to a raw-ms api** — use it
+  at the boundary; do not resort to `Date.now()` math inside domain logic.
+- **stamp vs float** — if you reach for a bare `'09:00:00'` string for a daily pattern, the
+  answer is `IsoTimeFloat`, not a raw string (see `rule.require.iso-time`).
+
+## .examples
+
+### 👎 bad — any-time shapes stored and computed
+
+```ts
+interface WaveReport {
+  observedAt: Date;                       // ambiguous zone
+  windowMs: number;                       // unit hidden
+}
+
+// hand-rolled ms math — a silent off-by-1000 waits here
+const staleAfter = report.observedAt.getTime() + report.windowMs;
+```
+
+### 👍 good — the glossary holds the shape and the math
+
+```ts
+import type { IsoTimeStamp, IsoDuration } from 'iso-time';
+import { addDuration } from 'iso-time';
+
+interface WaveReport {
+  observedAt: IsoTimeStamp;               // '2024-06-15T14:30:00Z'
+  window: IsoDuration;                    // { minutes: 20 }
+}
+
+const staleAfter = addDuration(report.observedAt, report.window);
+```
+
+## .enforcement
+
+- a time / date / duration declared as `Date`, `number`, or bare string in a domain object,
+  contract, or stored value = **blocker**
+- a `moment` / `dayjs` object as a stored or passed representation = **blocker**
+- hand-rolled millisecond arithmetic on an any-time value = **blocker**
+- an any-time value is a **false positive** only when it is transient input to an `as*` cast
+  at a boundary
+
+## .see also
+
+- `rule.require.iso-time` — the positive pair (what to use)
+- `.readme` (consistent.glossaries) — why the glossary family exists
+- `rule.forbid.magic-values` — the adjacent rule on hidden-unit primitives

--- a/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-time.md.min
+++ b/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.forbid.any-time.md.min
@@ -1,0 +1,65 @@
+# rule.forbid.any-time
+
+## .what
+do not represent a time/date/duration with an ANY-TIME shape — bare Date, number epoch, ad-hoc time string, moment/dayjs object, hand-rolled { hours; mins } bag — as the declared/stored/passed shape
+any-time = any representation OTHER THAN the canonical iso-time glossary. the loose, unconstrained twin of strict iso-time (rule.require.iso-time) — same sense `any` carries in typescript: could be any shape at all, compiler guarantees none
+
+## .why
+iso-time = adopted glossary for ergonomics + safety; an any-time shape forfeits both:
+- ambiguity — Date has implicit zone; '06/15/2024' reads june-or-6th per locale; a bare number hides its unit (s? ms?)
+- drift — an any-time duration invites hand-rolled ms math; an off-by-1000 hides for months. addDuration/getDuration cannot drift
+- sprawl — every any-time shape is a private map; 10 files grow 10 time shapes. the glossary is one territory
+
+## .the forbidden shapes
+- `bookedAt: Date` → IsoTimeStamp
+- `startsAt: string` → IsoDateStamp/IsoTimeFloat
+- `expiresAt: number` → IsoTimeStamp
+- `duration: number` → IsoDuration
+- `{ hrs, mins }` bag → IsoDurationShape
+- `moment()`/`dayjs()` object → iso-time cast
+- `Date.now() + 3600_000` → addDuration(now(), { hours: 1 })
+
+## .the one allowed use
+bare Date/number allowed ONLY as transient input to an as* cast at a boundary (clock/sdk); cast to an iso-time type at once, never stored/passed as any-time
+```ts
+const paddledOutAt = asIsoTimeStamp(sdkSession.startedAt); // Date -> IsoTimeStamp
+```
+
+## .reach for instead
+- `new Date(x)` to parse → asIsoTimeStamp/asIsoDateStamp
+- `Date.now()`/`new Date()` → now()/today()
+- `a.getTime() + ms` → addDuration(a, dur)
+- `a.getTime() - ms` → subDuration(a, dur)
+- `b.getTime() - a.getTime()` → getDuration({ of: { range: { since: a, until: b } } })
+- `ms1 + ms2` → sumDurations(dur1, dur2)
+- hand-rolled isValidDate → isIsoTimeStamp/isIsoDateStamp
+> read the full glossary: rhx git.repo.get lines --in ehmpathy/iso-time --paths 'readme.md'
+
+## .caveats
+- the boundary cast is the escape hatch, not a loophole — a Date may enter and be cast at once; it may not linger as a field/return/passed value
+- toMilliseconds(dur) is the sanctioned way to hand a duration to a raw-ms api; do not resort to Date.now() math in domain logic
+- stamp vs float — a bare '09:00:00' for a daily pattern → IsoTimeFloat, not a raw string (see rule.require.iso-time)
+
+## .examples
+👎 bad
+```ts
+interface WaveReport { observedAt: Date; windowMs: number; }
+const staleAfter = report.observedAt.getTime() + report.windowMs; // off-by-1000 waits
+```
+👍 good
+```ts
+import type { IsoTimeStamp, IsoDuration } from 'iso-time';
+import { addDuration } from 'iso-time';
+interface WaveReport { observedAt: IsoTimeStamp; window: IsoDuration; }
+const staleAfter = addDuration(report.observedAt, report.window);
+```
+
+## .enforcement
+- time/date/duration declared as Date/number/bare string in a domain object, contract, or stored value = blocker
+- moment/dayjs object as a stored/passed representation = blocker
+- hand-rolled ms arithmetic on an any-time value = blocker
+- any-time value is a false positive only as transient input to an as* cast at a boundary
+
+## .see also
+- rule.require.iso-time — the positive pair
+- rule.forbid.magic-values — the adjacent rule on hidden-unit primitives

--- a/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.require.iso-price.md
+++ b/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.require.iso-price.md
@@ -1,0 +1,154 @@
+# rule.require.iso-price
+
+## .what
+
+represent every money and price value with the **`iso-price`** glossary types.
+`iso-price` is the adopted ubiqlang glossary for money; `IsoPriceWords` (a string like
+`'USD 50.37'`) is the one canonical representation a price takes when it is declared on a
+domain object, passed through a contract, or stored.
+
+cast raw inputs into the glossary at the boundary with `asIsoPrice`; do price arithmetic
+through the glossary's operations (`priceSum`, `priceMultiply`, …), never with raw numbers.
+
+## .why
+
+`iso-price` is adopted for **ergonomics** and **safety** — the two reasons the whole
+glossary family exists:
+
+- **safety** — money math on a raw `number` is wrong by construction: `0.1 + 0.2` is
+  `0.30000000000000004`. `iso-price` does lossless bigint arithmetic under the hood, knows
+  each currency's iso 4217 exponent, and carries the currency in the value itself — so a
+  price can never lose precision, drift, or be added to the wrong currency.
+- **ergonomics** — words in, words out: `priceSum('USD 0.10', 'USD 0.20')` is `'USD 0.30'`.
+  one obvious cast (`asIsoPrice`), one obvious display (`asIsoPriceHuman`), one obvious
+  structured read (`asIsoPriceShape`). the common case is a one-liner.
+
+a bare `number` is a map that dropped the currency and the precision; `IsoPriceWords` is the
+territory — one validated, serializable, composable shape the whole codebase shares.
+
+## .the glossary
+
+| form | type | shape |
+|------|------|-------|
+| canonical (default) | `IsoPriceWords` | `'USD 50.37'` |
+| structured | `IsoPriceShape` | `{ amount: 5037n, currency: 'USD', exponent: 'centi.x10^-2' }` |
+| localized display | `IsoPriceHuman` | `'$50.37'` |
+
+## .the operations
+
+we use the **`price*` (noun-first)** form of each arithmetic op — it groups every price
+operation together under one autocomplete prefix (`rule.require.order.noun_adj`). the
+verb-first aliases (`sumPrices`, `multiplyPrice`, …) name the same op; prefer `price*`.
+
+| kind | operation | does |
+|------|-----------|------|
+| cast | `asIsoPrice` (= `asIsoPriceWords`) | any input → canonical words `'USD 50.37'` |
+| cast | `asIsoPriceShape` | words → `{ amount: 5037n, currency, exponent }` |
+| cast | `asIsoPriceHuman` | words → localized display `'$50.37'` |
+| sort | `asIsoPrice.sorted` (`.asc` / `.desc`) | numeric sort of a price list |
+| arithmetic | `priceSum(...prices)` | add prices |
+| arithmetic | `priceSub(a, b)` | subtract |
+| arithmetic | `priceMultiply({ of, by })` | scale by a scalar |
+| arithmetic | `priceDivide({ of, by })` | divide by a scalar |
+| arithmetic | `priceAllocate({ of, into, remainder })` | split without losing a cent |
+| precision | `setPricePrecision({ of, to })`, `roundPrice({ of })` | change/round precision |
+| statistics | `calcPriceAvg(prices)`, `calcPriceStdev(prices)` | aggregate |
+| guard | `isIsoPrice` (+ `.greater` / `.lesser` / `.equal`) | validate + numeric compare |
+
+`asIsoPrice` accepts any input — `'$50.37'`, `'USD 50.37'`, `{ amount, currency }`, bigint
+amounts — and returns canonical words.
+
+> read the full glossary:
+> `rhx git.repo.get lines --in ehmpathy/iso-price --paths 'readme.md'`
+
+## .caveats
+
+- **`IsoPriceWords` is the one you store and pass.** `IsoPriceHuman` (`'$50.37'`) is
+  display-only — locale-bound, lossy — so keep it at the ui edge; `IsoPriceShape` is for
+  structured reads (bigint amount, exponent).
+- **precision follows iso 4217 by default.** `asIsoPrice('$7')` → `'USD 7.00'` (2 decimals),
+  `asIsoPrice('¥1000')` → `'JPY 1000'` (0). custom currencies default to 2 decimals. override
+  with `{ exponent }`, and round explicitly with `{ round: 'half-up' }` when you need to.
+- **precision is preserved to the most granular input** — `priceSum('USD 50.00',
+  'USD 0.000_005')` keeps the micro-precision. this is a feature, not drift.
+- **compare with `isIsoPrice.equal`**, not `===` — `'USD 0.25'` and `'USD 0.250_000'` are
+  equal in value but not as strings.
+
+## .scope
+
+applies to the **representation** of a money value:
+
+- a field on a domain object or type (a price, a total, a fee, a balance)
+- an input/output shape on a contract or operation
+- a value persisted or passed between operations
+
+a bare `number` / `'$50.37'` string / `{ amount, currency }` bag is allowed **only** as
+transient input to `asIsoPrice` at a boundary. the declared, stored, passed shape is
+`IsoPriceWords`.
+
+## .how
+
+- **declare** price fields as `IsoPriceWords`, never `number`
+- **cast at the boundary** — `asIsoPrice(sdkCharge.amount)` the moment a raw price enters
+- **compute** through `priceSum` / `priceMultiply` / `priceDivide`, never `a + b` on raw money numbers
+- **compare** through `isIsoPrice.greater` / `.lesser` / `.equal`, which handle precision
+- **display** through `asIsoPriceHuman` at the ui edge only
+
+## .examples
+
+### 👎 bad — any-price number as the representation, float math
+
+```ts
+interface BoardRental {
+  pricePerDay: number;      // dollars? cents? which currency?
+}
+
+// float drift — a customer is charged $0.30000000000000004
+const total = rental.pricePerDay * 0.1 + rental.pricePerDay * 0.2;
+```
+
+### 👍 good — the iso-price glossary as the representation
+
+```ts
+import type { IsoPriceWords } from 'iso-price';
+import { priceSum, priceMultiply, priceDivide } from 'iso-price';
+
+interface BoardRental {
+  pricePerDay: IsoPriceWords;             // 'USD 45.00'
+}
+
+// lossless, currency-safe arithmetic
+const weekend = priceSum(rental.pricePerDay, rental.pricePerDay);   // 'USD 90.00'
+const week = priceMultiply({ of: rental.pricePerDay, by: 7 });      // 'USD 315.00'
+const halfDay = priceDivide({ of: rental.pricePerDay, by: 2 });     // 'USD 22.50'
+```
+
+### 👍 good — cast at the boundary
+
+```ts
+import { asIsoPrice } from 'iso-price';
+
+// sdk hands back cents + currency; cast once at the boundary
+const charged = asIsoPrice({ amount: sdkCharge.amount, currency: sdkCharge.currency });
+```
+
+## .exceptions
+
+- **transient cast input** — a `number` / display string / `{ amount, currency }` handed to
+  `asIsoPrice` at a boundary
+- **third-party contracts** — an sdk/api money type you do not own; cast to `iso-price` the
+  moment it crosses into our code
+
+## .enforcement
+
+- a money / price / fee / total declared as `number` in a domain object, contract, or stored
+  value = **blocker**
+- raw arithmetic (`+`, `*`, `/`) on money numbers where `priceSum` / `priceMultiply` /
+  `priceDivide` applies = **blocker**
+
+## .see also
+
+- `rule.forbid.any-price` — the negative pair (what not to use)
+- `.readme` (consistent.glossaries) — why the glossary family exists
+- `rule.require.ubiqlang` — one canonical representation per concept
+- `rule.require.read-package-docs-before-use` — read the iso-price readme first

--- a/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.require.iso-price.md.min
+++ b/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.require.iso-price.md.min
@@ -1,0 +1,76 @@
+# rule.require.iso-price
+
+## .what
+represent every money/price value with the `iso-price` glossary types — the adopted ubiqlang glossary for money. IsoPriceWords (a string like 'USD 50.37') is the canonical representation. cast raw inputs at the boundary with asIsoPrice; do arithmetic through priceSum/priceMultiply/priceDivide, never raw numbers
+
+## .why
+adopted for ergonomics + safety (the glossary-family reasons):
+- safety — money math on a raw number is wrong by construction (0.1 + 0.2 = 0.30000000000000004). iso-price does lossless bigint arithmetic, knows each currency's iso 4217 exponent, carries the currency in the value — so no lost precision, no drift, no cross-currency add
+- ergonomics — words in, words out: priceSum('USD 0.10','USD 0.20') = 'USD 0.30'. one cast (asIsoPrice), one display (asIsoPriceHuman), one structured read (asIsoPriceShape)
+a bare number = a map that dropped the currency + precision; IsoPriceWords = the territory
+
+## .the glossary
+- IsoPriceWords (default) `'USD 50.37'`
+- IsoPriceShape `{ amount: 5037n, currency: 'USD', exponent: 'centi.x10^-2' }`
+- IsoPriceHuman `'$50.37'`
+
+## .the operations
+use the price* (noun-first) form — groups every price op under one autocomplete prefix (rule.require.order.noun_adj). verb-first aliases (sumPrices, multiplyPrice, …) name the same op; prefer price*
+- cast: asIsoPrice (=asIsoPriceWords) any input → 'USD 50.37'; asIsoPriceShape → { amount, currency, exponent }; asIsoPriceHuman → '$50.37'
+- sort: asIsoPrice.sorted (.asc/.desc)
+- arithmetic: priceSum(...prices), priceSub(a,b), priceMultiply({ of, by }), priceDivide({ of, by }), priceAllocate({ of, into, remainder })
+- precision: setPricePrecision({ of, to }), roundPrice({ of })
+- statistics: calcPriceAvg(prices), calcPriceStdev(prices)
+- guard: isIsoPrice (+ .greater/.lesser/.equal)
+- asIsoPrice accepts any input ('$50.37', 'USD 50.37', { amount, currency }, bigint) → canonical words
+> read the full glossary: rhx git.repo.get lines --in ehmpathy/iso-price --paths 'readme.md'
+
+## .caveats
+- IsoPriceWords is the one you store/pass. IsoPriceHuman ('$50.37') is display-only (locale-bound, lossy) — keep at the ui edge; IsoPriceShape is for structured reads
+- precision follows iso 4217 by default: asIsoPrice('$7')='USD 7.00' (2dp), asIsoPrice('¥1000')='JPY 1000' (0dp). custom currencies default to 2dp. override with { exponent }, round with { round: 'half-up' }
+- precision preserved to the most granular input — priceSum('USD 50.00','USD 0.000_005') keeps micro precision (a feature, not drift)
+- compare with isIsoPrice.equal not === ('USD 0.25' equals 'USD 0.250_000' in value, not as strings)
+
+## .scope
+applies to the REPRESENTATION: a price/total/fee/balance field on a domain object/type, a contract/operation i/o shape, a persisted/passed value
+bare number / '$50.37' string / { amount, currency } bag allowed ONLY as transient input to asIsoPrice at a boundary. the declared/stored/passed shape is IsoPriceWords
+
+## .how
+- declare price fields as IsoPriceWords, never number
+- cast at the boundary — asIsoPrice(sdkCharge.amount) the moment a raw price enters
+- compute via priceSum/priceMultiply/priceDivide, never a + b on raw money numbers
+- compare via isIsoPrice.greater/.lesser/.equal (handle precision)
+- display via asIsoPriceHuman at the ui edge only
+
+## .examples
+👎 bad
+```ts
+interface BoardRental { pricePerDay: number; }
+const total = rental.pricePerDay * 0.1 + rental.pricePerDay * 0.2; // float drift
+```
+👍 good
+```ts
+import type { IsoPriceWords } from 'iso-price';
+import { priceSum, priceMultiply, priceDivide } from 'iso-price';
+interface BoardRental { pricePerDay: IsoPriceWords; }
+const weekend = priceSum(rental.pricePerDay, rental.pricePerDay);  // 'USD 90.00'
+const week = priceMultiply({ of: rental.pricePerDay, by: 7 });     // 'USD 315.00'
+const halfDay = priceDivide({ of: rental.pricePerDay, by: 2 });    // 'USD 22.50'
+```
+👍 cast at boundary
+```ts
+const charged = asIsoPrice({ amount: sdkCharge.amount, currency: sdkCharge.currency });
+```
+
+## .exceptions
+- transient cast input: a number/display string/{ amount, currency } handed to asIsoPrice at a boundary
+- third-party contracts: an sdk/api money type you do not own; cast to iso-price the moment it crosses in
+
+## .enforcement
+- money/price/fee/total declared as number in a domain object, contract, or stored value = blocker
+- raw +/*/ arithmetic on money numbers where priceSum/priceMultiply/priceDivide applies = blocker
+
+## .see also
+- rule.forbid.any-price — the negative pair
+- rule.require.ubiqlang — one canonical representation per concept
+- rule.require.read-package-docs-before-use — read the iso-price readme first

--- a/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.require.iso-time.md
+++ b/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.require.iso-time.md
@@ -1,0 +1,147 @@
+# rule.require.iso-time
+
+## .what
+
+represent every time, date, and duration value with the **`iso-time`** glossary types.
+`iso-time` is the adopted ubiqlang glossary for time; its types are the one canonical
+representation a time value takes when it is declared on a domain object, passed through a
+contract, or stored.
+
+cast raw inputs into the glossary at the boundary with the `as*` casts; from there on, the
+value is an `iso-time` type.
+
+## .why
+
+`iso-time` is adopted for **ergonomics** and **safety** — the same two reasons the whole
+glossary family exists:
+
+- **safety** — a strict iso 8601 type is unambiguous. `'2024-06-15'` reads one way in every
+  locale; a bare `'06/15/2024'` string or a `Date` with an implicit zone does not. the type
+  also draws the **stamp vs float** line the domain actually has (an absolute instant vs a
+  detached pattern), so a re-read never confuses "when it happened" with "when it repeats".
+- **ergonomics** — one obvious cast (`asIsoTimeStamp(new Date())`), one obvious duration
+  (`'PT30M'` or `{ minutes: 30 }`), one obvious arithmetic (`addDuration`, `getDuration`).
+  the common case is a one-liner and the names read as a human expects.
+
+a raw `number` epoch or `Date` is a map some prior code drew; the `iso-time` type is the
+territory — one validated shape the whole codebase shares.
+
+## .the glossary
+
+| kind | type | shape |
+|------|------|-------|
+| absolute instant | `IsoTimeStamp` | `2024-06-15T14:30:00Z` |
+| absolute date | `IsoDateStamp` | `2024-06-15` |
+| absolute month | `IsoMonthStamp` | `2024-06` |
+| detached time | `IsoTimeFloat` | `14:30:00` |
+| detached weekday | `IsoWeekdayFloat` | `1` (monday) |
+| duration | `IsoDuration` (`IsoDurationWords` `'PT30M'` \| `IsoDurationShape` `{ minutes: 30 }`) |
+| range | `IsoTimeStampRange`, `IsoDateStampRange` | `{ since, until }` |
+
+## .the operations
+
+| kind | operation | does |
+|------|-----------|------|
+| cast | `asIsoTimeStamp`, `asIsoDateStamp`, `asIsoMonthStamp` | any input → strict iso stamp |
+| cast | `asIsoTimeFloat`, `asIsoHourFloat`, `asIsoWeekdayFloat`, … | extract a detached time component |
+| cast | `asIsoTimeStampRange`, `asIsoDateStampRange` | `{ since, until }` → strict range |
+| guard | `isIsoTimeStamp`, `isIsoDateStamp`, … | validate/narrow a string's format |
+| arithmetic | `addDuration(stamp, dur)` | shift a stamp forward |
+| arithmetic | `subDuration(stamp, dur)` | shift a stamp back |
+| arithmetic | `getDuration({ of: { range } })` | the duration between two stamps |
+| arithmetic | `sumDurations(...durs)` | add durations together |
+| convert | `toMilliseconds(dur)` | a duration → raw ms (boundary use only) |
+| observe | `now()`, `today()` | read the clock as a stamp — use these, not `new Date()` |
+| sleep | `sleep(dur)` | await a duration |
+
+> read the full glossary:
+> `rhx git.repo.get lines --in ehmpathy/iso-time --paths 'readme.md'`
+
+## .caveats
+
+- **stamp vs float is the core split.** a **stamp** is an absolute instant (`IsoTimeStamp`
+  `'2024-06-15T14:30:00Z'`); a **float** is a detached pattern (`IsoTimeFloat` `'09:00:00'`,
+  every day at 9). pick the one the domain means — "when it happened" is a stamp, "when it
+  repeats" is a float.
+- **durations have two forms.** `IsoDurationWords` (`'PT30M'`) is concise for inputs;
+  `IsoDurationShape` (`{ minutes: 30 }`) is easy to manipulate, so operations return it by
+  default. `IsoDuration` accepts either.
+- **read the clock through `now()` / `today()`**, never `new Date()` in domain logic — it
+  keeps the value in the glossary and keeps tests deterministic.
+- **`toMilliseconds` is a boundary escape hatch** — use it to hand a duration to a raw api
+  that wants ms; do not route domain arithmetic through it.
+
+## .scope
+
+applies to the **representation** of a time value:
+
+- a field on a domain object or type
+- an input/output shape on a contract or operation
+- a value persisted or passed between operations
+
+a bare `Date` or `number` is allowed **only** as transient input to an `as*` cast at a
+boundary (an sdk that returns unix seconds, a `new Date()` read of the clock). the declared,
+stored, passed shape is an `iso-time` type.
+
+## .how
+
+- **declare** time fields as `iso-time` types, never `Date` / `number` / bare string
+- **cast at the boundary** — `asIsoTimeStamp(sdkValue)` the moment a raw time enters
+- **read the clock** through `now()` / `today()`, not `new Date()` in domain logic
+- **durations** as `IsoDuration`; **arithmetic** through `addDuration` / `getDuration`, never
+  hand-rolled millisecond math
+
+## .examples
+
+### 👎 bad — raw primitives as the representation
+
+```ts
+interface SurfLesson {
+  bookedAt: Date;          // implicit zone; ambiguous on the wire
+  startsAt: string;        // '06/15/2024'? '15/06'? unknowable
+  duration: number;        // 30? minutes? seconds? ms?
+}
+```
+
+### 👍 good — the iso-time glossary as the representation
+
+```ts
+import type { IsoTimeStamp, IsoTimeFloat, IsoDuration } from 'iso-time';
+
+interface SurfLesson {
+  bookedAt: IsoTimeStamp;  // '2024-06-15T14:30:00Z' — absolute, unambiguous
+  startsAt: IsoTimeFloat;  // '09:00:00' — detached daily pattern
+  duration: IsoDuration;   // { minutes: 30 } or 'PT30M'
+}
+```
+
+### 👍 good — cast at the boundary, compute through the glossary
+
+```ts
+import { asIsoTimeStamp, addDuration, now } from 'iso-time';
+
+// sdk hands back a Date; cast it once at the boundary
+const bookedAt = asIsoTimeStamp(sdkReservation.createdAt);
+
+// arithmetic through the glossary, never raw ms math
+const endsAt = addDuration(asIsoTimeStamp(now()), { minutes: 30 });
+```
+
+## .exceptions
+
+- **transient cast input** — a `Date` / `number` handed to an `as*` cast at a boundary
+- **third-party contracts** — an sdk/api type you do not own; cast to `iso-time` the moment
+  it crosses into our code
+
+## .enforcement
+
+- a time / date / duration declared as `Date`, `number`, or bare string in a domain object,
+  contract, or stored value = **blocker**
+- hand-rolled millisecond arithmetic where `addDuration` / `getDuration` applies = **blocker**
+
+## .see also
+
+- `rule.forbid.any-time` — the negative pair (what not to use)
+- `.readme` (consistent.glossaries) — why the glossary family exists
+- `rule.require.ubiqlang` — one canonical representation per concept
+- `rule.require.read-package-docs-before-use` — read the iso-time readme first

--- a/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.require.iso-time.md.min
+++ b/src/domain.roles/mechanic/briefs/practices/code.prod/consistent.glossaries/rule.require.iso-time.md.min
@@ -1,0 +1,71 @@
+# rule.require.iso-time
+
+## .what
+represent every time/date/duration value with the `iso-time` glossary types — the adopted ubiqlang glossary for time. cast raw inputs into the glossary at the boundary with as*; from there the value is an iso-time type
+
+## .why
+adopted for ergonomics + safety (the glossary-family reasons):
+- safety — strict iso 8601 is unambiguous ('2024-06-15' reads one way everywhere; a bare '06/15/2024' or a Date with implicit zone does not). draws the stamp-vs-float line the domain has (absolute instant vs detached pattern)
+- ergonomics — one obvious cast (asIsoTimeStamp), one obvious duration ('PT30M' | { minutes: 30 }), one obvious arithmetic (addDuration/getDuration). common case = one-liner
+raw number/Date = a map prior code drew; the iso-time type = the territory
+
+## .the glossary
+- IsoTimeStamp `2024-06-15T14:30:00Z`, IsoDateStamp `2024-06-15`, IsoMonthStamp `2024-06`
+- IsoTimeFloat `14:30:00`, IsoWeekdayFloat `1`
+- IsoDuration = IsoDurationWords `'PT30M'` | IsoDurationShape `{ minutes: 30 }`
+- ranges: IsoTimeStampRange, IsoDateStampRange `{ since, until }`
+
+## .the operations
+- cast: asIsoTimeStamp/asIsoDateStamp/asIsoMonthStamp (input → strict stamp); asIsoTimeFloat/asIsoHourFloat/asIsoWeekdayFloat (extract detached component); asIsoTimeStampRange/asIsoDateStampRange
+- guard: isIsoTimeStamp/isIsoDateStamp/... (validate/narrow format)
+- arithmetic: addDuration(stamp,dur), subDuration(stamp,dur), getDuration({ of: { range } }), sumDurations(...durs)
+- convert: toMilliseconds(dur) — dur → raw ms (boundary only)
+- observe: now(), today() — read the clock as a stamp; use these, not new Date()
+- sleep: sleep(dur)
+> read the full glossary: rhx git.repo.get lines --in ehmpathy/iso-time --paths 'readme.md'
+
+## .caveats
+- stamp vs float is the core split: stamp = absolute instant (IsoTimeStamp); float = detached pattern (IsoTimeFloat). "when it happened" = stamp, "when it repeats" = float
+- durations have two forms: IsoDurationWords ('PT30M') concise for input; IsoDurationShape ({ minutes: 30 }) easy to manipulate, returned by default. IsoDuration accepts either
+- read the clock via now()/today(), never new Date() in domain logic (keeps value in glossary + tests deterministic)
+- toMilliseconds is a boundary escape hatch (hand a duration to a raw ms api); do not route domain arithmetic through it
+
+## .scope
+applies to the REPRESENTATION: a field on a domain object/type, a contract/operation i/o shape, a persisted/passed value
+bare Date/number allowed ONLY as transient input to an as* cast at a boundary (sdk unix seconds, new Date() clock read). the declared/stored/passed shape is an iso-time type
+
+## .how
+- declare time fields as iso-time types, never Date/number/bare string
+- cast at the boundary — asIsoTimeStamp(sdkValue) the moment a raw time enters
+- read the clock via now()/today(), not new Date() in domain logic
+- durations as IsoDuration; arithmetic via addDuration/getDuration, never hand-rolled ms math
+
+## .examples
+👎 bad
+```ts
+interface SurfLesson { bookedAt: Date; startsAt: string; duration: number; }
+```
+👍 good
+```ts
+import type { IsoTimeStamp, IsoTimeFloat, IsoDuration } from 'iso-time';
+interface SurfLesson { bookedAt: IsoTimeStamp; startsAt: IsoTimeFloat; duration: IsoDuration; }
+```
+👍 cast at boundary, compute through glossary
+```ts
+import { asIsoTimeStamp, addDuration, now } from 'iso-time';
+const bookedAt = asIsoTimeStamp(sdkReservation.createdAt);
+const endsAt = addDuration(asIsoTimeStamp(now()), { minutes: 30 });
+```
+
+## .exceptions
+- transient cast input: a Date/number handed to an as* cast at a boundary
+- third-party contracts: an sdk/api type you do not own; cast to iso-time the moment it crosses in
+
+## .enforcement
+- time/date/duration declared as Date/number/bare string in a domain object, contract, or stored value = blocker
+- hand-rolled ms arithmetic where addDuration/getDuration applies = blocker
+
+## .see also
+- rule.forbid.any-time — the negative pair
+- rule.require.ubiqlang — one canonical representation per concept
+- rule.require.read-package-docs-before-use — read the iso-time readme first


### PR DESCRIPTION
fix(briefs): add iso-time/iso-price glossary rules

- new consistent.glossaries practice dir for adopted ubiqlang glossaries
- rule.require.iso-time / rule.forbid.any-time
- rule.require.iso-price / rule.forbid.any-price
- why: adopted glossaries for ergonomics + safety (unambiguous iso 8601,
  iso 4217 + lossless bigint money math)
- itemized operations (price* noun-first forms), caveats, readme pointers
- wired into mechanic boot.yml subject.code.prod

---
🐢🌊 surfed in by seaturtle[bot]